### PR TITLE
test(ci): split e2e test jobs in three parallel jobs

### DIFF
--- a/.github/workflows/test-app-e2e.yaml
+++ b/.github/workflows/test-app-e2e.yaml
@@ -31,11 +31,20 @@ jobs:
       matrix:
         node-version: [16]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        group: [0, 1]
         include:
           - node-version: 12
             os: ubuntu-latest
+            group: 0
+          - node-version: 12
+            os: ubuntu-latest
+            group: 1
           - node-version: 14
             os: ubuntu-latest
+            group: 0
+          - node-version: 14
+            os: ubuntu-latest
+            group: 1
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -53,7 +62,10 @@ jobs:
         with:
           version: 6.24.4
           run_install: true
-      - run: pnpm turbo run e2e-test --scope="@previewjs/app" --include-dependencies
+      - run: pnpm turbo run e2e-test:group --scope="@previewjs/app" --include-dependencies
+        env:
+          GROUP_INDEX: ${{ matrix.group }}
+          GROUP_COUNT: 2
       - name: Update screenshots on non-main branches
         run: |
           if [ -z "$(git status --porcelain)" ]; then

--- a/.github/workflows/test-app-e2e.yaml
+++ b/.github/workflows/test-app-e2e.yaml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         node-version: [16]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        group: [0, 1]
+        group: [0, 1, 2]
         include:
           - node-version: 12
             os: ubuntu-latest
@@ -39,12 +39,18 @@ jobs:
           - node-version: 12
             os: ubuntu-latest
             group: 1
+          - node-version: 12
+            os: ubuntu-latest
+            group: 2
           - node-version: 14
             os: ubuntu-latest
             group: 0
           - node-version: 14
             os: ubuntu-latest
             group: 1
+          - node-version: 14
+            os: ubuntu-latest
+            group: 2
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
@@ -65,7 +71,7 @@ jobs:
       - run: pnpm turbo run e2e-test:group --scope="@previewjs/app" --include-dependencies
         env:
           GROUP_INDEX: ${{ matrix.group }}
-          GROUP_COUNT: 2
+          GROUP_COUNT: 3
       - name: Update screenshots on non-main branches
         run: |
           if [ -z "$(git status --porcelain)" ]; then


### PR DESCRIPTION
This was previously reverted when there were 4 parallel jobs, but 2 jobs may be the right fit.