### PR TITLE
fix: IntelliJ plugin crashes with files larger than 100kb

### DIFF
--- a/integrations/intellij/controller/src/run-server.ts
+++ b/integrations/intellij/controller/src/run-server.ts
@@ -44,7 +44,11 @@ async function main() {
   const previews: Record<string, Preview> = {};
 
   const app = express();
-  app.use(express.json());
+  app.use(
+    express.json({
+      limit: "2mb",
+    })
+  );
   app.get("/health", (_req, res) => {
     res.json({
       ready: true,

--- a/integrations/intellij/src/main/kotlin/com/previewjs/intellij/plugin/services/ProjectService.kt
+++ b/integrations/intellij/src/main/kotlin/com/previewjs/intellij/plugin/services/ProjectService.kt
@@ -73,7 +73,7 @@ class ProjectService(private val project: Project) : Disposable {
         EditorFactory.getInstance().eventMulticaster.addDocumentListener(object : DocumentListener {
             override fun documentChanged(event: DocumentEvent) {
                 val file = FileDocumentManager.getInstance().getFile(event.document)
-                if (file != null && file.isInLocalFileSystem && file.isWritable) {
+                if (file != null && file.isInLocalFileSystem && file.isWritable && event.document.text.length <= 1_048_576) {
                     service.enqueueAction(project) { workspace ->
                         workspace.update(file.path, event.document.text)
                     }


### PR DESCRIPTION
This involves the following:
- explicitly setting the maximum size allowed in requests to 2mb (default is 100kb)
- not sending update requests for files larger than 1mb

We should also consider not using JSON for this request to reduce CPU load, although that may need to be benchmarked.

This should fix #232.