### PR TITLE
fix: set __dirname and __filename to undefined explicitly

### DIFF
--- a/core/src/vite/vite-manager.ts
+++ b/core/src/vite/vite-manager.ts
@@ -213,6 +213,8 @@ export class ViteManager {
       plugins,
       define: {
         "process.env": process.env,
+        __filename: undefined,
+        __dirname: undefined,
         ...frameworkPluginViteConfig.define,
         ...this.options.config.vite?.define,
       },


### PR DESCRIPTION
This prevents a crash with <Link> in NextJS 12 for example, see https://github.com/fwouts/previewjs/pull/300.