### PR TITLE
feat(react): enable SVGR plugin to be disabled

### DIFF
--- a/frameworks/react/src/index.ts
+++ b/frameworks/react/src/index.ts
@@ -11,6 +11,7 @@ import { svgrPlugin } from "./svgr-plugin";
 export const reactFrameworkPlugin: FrameworkPluginFactory<{
   svgr?: {
     componentName?: string;
+    disable?: boolean;
   };
 }> = {
   isCompatible: async (dependencies) => {
@@ -57,10 +58,13 @@ export const reactFrameworkPlugin: FrameworkPluginFactory<{
         return {
           plugins: [
             optimizeReactDepsPlugin(),
-            svgrPlugin({
-              exportedComponentName: svgr?.componentName || "ReactComponent",
-              alias: config.alias,
-            }),
+            svgr?.disable
+              ? null
+              : svgrPlugin({
+                  exportedComponentName:
+                    svgr?.componentName || "ReactComponent",
+                  alias: config.alias,
+                }),
             reactImportsPlugin(),
           ],
           define: {


### PR DESCRIPTION
This should help in cases like https://github.com/fwouts/previewjs/issues/442 where developers prefer to provide their own Vite plugin to handle SVGR.