### PR TITLE
Make `alias` options into optional.

### DIFF
--- a/config/src/config.ts
+++ b/config/src/config.ts
@@ -2,7 +2,7 @@ import type { UserConfig } from "vite";
 
 export interface PreviewConfig {
   /** @deprecated Use the `vite.resolve.alias` field instead. */
-  alias: Record<string, string>;
+  alias?: Record<string, string>;
   publicDir: string;
   wrapper?: {
     path: string;


### PR DESCRIPTION
We don't need to set this option required if it was deprecated.