### PR TITLE
fix(react): explicitly exclude incompatible React v16.13 and earlier versions

### DIFF
--- a/frameworks/react/src/index.ts
+++ b/frameworks/react/src/index.ts
@@ -13,7 +13,14 @@ const reactFrameworkPlugin: FrameworkPluginFactory = {
     if (!version) {
       return false;
     }
-    return parseInt(version) >= 16;
+    const [major, minor] = version.split(".").map((n) => parseInt(n)) as [
+      number,
+      number
+    ];
+    if (isNaN(major) || isNaN(minor)) {
+      return false;
+    }
+    return major >= 17 || (major === 16 && minor >= 14);
   },
   async create({ rootDirPath, dependencies }) {
     const previewDirPath = path.join(__dirname, "..", "preview");


### PR DESCRIPTION
This should address #1360.