### PR TITLE
refactor: remove iframe loading animation

### DIFF
--- a/iframe/preview/index.html
+++ b/iframe/preview/index.html
@@ -22,102 +22,11 @@
         font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
           monospace;
       }
-
-      .previewjs-loader {
-        background: #1f2937;
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
-        align-items: center;
-        position: absolute;
-        left: 0;
-        top: 0;
-        right: 0;
-        bottom: 0;
-      }
     </style>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>
   <body>
-    <div id="root">
-      <div class="previewjs-loader">
-        <!-- By Sam Herbert (@sherb), for everyone. More @ http://goo.gl/7AJzbL -->
-        <svg
-          width="120"
-          height="30"
-          viewBox="0 0 120 30"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="#fff"
-        >
-          <circle cx="15" cy="15" r="15">
-            <animate
-              attributeName="r"
-              from="15"
-              to="15"
-              begin="0s"
-              dur="0.8s"
-              values="15;9;15"
-              calcMode="linear"
-              repeatCount="indefinite"
-            />
-            <animate
-              attributeName="fill-opacity"
-              from="1"
-              to="1"
-              begin="0s"
-              dur="0.8s"
-              values="1;.5;1"
-              calcMode="linear"
-              repeatCount="indefinite"
-            />
-          </circle>
-          <circle cx="60" cy="15" r="9" fill-opacity="0.3">
-            <animate
-              attributeName="r"
-              from="9"
-              to="9"
-              begin="0s"
-              dur="0.8s"
-              values="9;15;9"
-              calcMode="linear"
-              repeatCount="indefinite"
-            />
-            <animate
-              attributeName="fill-opacity"
-              from="0.5"
-              to="0.5"
-              begin="0s"
-              dur="0.8s"
-              values=".5;1;.5"
-              calcMode="linear"
-              repeatCount="indefinite"
-            />
-          </circle>
-          <circle cx="105" cy="15" r="15">
-            <animate
-              attributeName="r"
-              from="15"
-              to="15"
-              begin="0s"
-              dur="0.8s"
-              values="15;9;15"
-              calcMode="linear"
-              repeatCount="indefinite"
-            />
-            <animate
-              attributeName="fill-opacity"
-              from="1"
-              to="1"
-              begin="0s"
-              dur="0.8s"
-              values="1;.5;1"
-              calcMode="linear"
-              repeatCount="indefinite"
-            />
-          </circle>
-        </svg>
-      </div>
-    </div>
+    <div id="root"></div>
   </body>
 </html>


### PR DESCRIPTION
This will be replaced with an animation in the top-level document instead, overlapping the iframe. It should allow for a smoother transition (e.g. showing the iframe in the background with translucency) and will simplify the core iframe.