### PR TITLE
fix: do not override syntactically incorrect unknown values

### DIFF
--- a/serializable-values/src/serializable-value-to-js.spec.ts
+++ b/serializable-values/src/serializable-value-to-js.spec.ts
@@ -182,14 +182,17 @@ describe("serializableValueToJavaScript", () => {
     expect(serializableValueToJavaScript(unknown("foo"))).toMatchInlineSnapshot(
       '"foo"'
     );
+    expect(
+      serializableValueToJavaScript(unknown("foo bar"))
+    ).toMatchInlineSnapshot('"foo bar"');
     expect(serializableValueToJavaScript(unknown("new"))).toMatchInlineSnapshot(
-      '"{}"'
+      '"new"'
     );
     expect(serializableValueToJavaScript(unknown("'"))).toMatchInlineSnapshot(
-      '"{}"'
+      '"\'"'
     );
     expect(serializableValueToJavaScript(unknown(""))).toMatchInlineSnapshot(
-      '"{}"'
+      '""'
     );
   });
 });

--- a/serializable-values/src/serializable-value-to-js.ts
+++ b/serializable-values/src/serializable-value-to-js.ts
@@ -100,9 +100,8 @@ function serializableValueToUnformattedJavaScript(
       return JSON.stringify(value.value);
     case "undefined":
       return "undefined";
-    case "unknown": {
+    case "unknown":
       return value.source ?? "{}";
-    }
     default:
       throw assertNever(value);
   }

--- a/serializable-values/src/serializable-value-to-js.ts
+++ b/serializable-values/src/serializable-value-to-js.ts
@@ -101,14 +101,7 @@ function serializableValueToUnformattedJavaScript(
     case "undefined":
       return "undefined";
     case "unknown": {
-      const source = value.source ?? "{}";
-      try {
-        formatExpression(source);
-        // It didn't throw? Cool, that must be good to return.
-        return source;
-      } catch {
-        return "{}";
-      }
+      return value.source ?? "{}";
     }
     default:
       throw assertNever(value);


### PR DESCRIPTION
This can get in the way of someone who is in the middle of writing a valid expression.