### PR TITLE
chore: revert TypeScript 5 because of JSX detection issues

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -27,7 +27,7 @@
     "axios": "^1.3.4"
   },
   "devDependencies": {
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "unbuild": "^1.1.2"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -40,7 +40,7 @@
     "@types/node": "^18.15.3",
     "cross-env": "^7.0.3",
     "fs-extra": "^11.1.0",
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "unbuild": "^1.1.2",
     "vite": "^4.2.0"
   }

--- a/chromeless/package.json
+++ b/chromeless/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@types/express": "^4.17.17",
     "rimraf": "^4.4.0",
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "unbuild": "^1.1.2",
     "vite": "^4.2.0"
   }

--- a/config-helpers/nextjs/package.json
+++ b/config-helpers/nextjs/package.json
@@ -32,7 +32,7 @@
     "@types/react": "^18.0.28",
     "next": "^13.2.4",
     "react": "^18.2.0",
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "unbuild": "^1.1.2"
   },
   "peerDependencies": {

--- a/config/package.json
+++ b/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@previewjs/config",
-  "version": "5.0.2",
+  "version": "4.9.5",
   "license": "MIT",
   "author": {
     "name": "François Wouts",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.15.3",
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "unbuild": "^1.1.2",
     "vite": "^4.2.0"
   }

--- a/core/package.json
+++ b/core/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@previewjs/api": "^9.0.2",
-    "@previewjs/config": "^5.0.2",
+    "@previewjs/config": "^4.9.5",
     "@previewjs/iframe": "^8.0.1",
     "@previewjs/serializable-values": "^5.0.1",
     "@previewjs/type-analyzer": "^6.0.4",
@@ -43,7 +43,7 @@
     "rollup-plugin-friendly-type-imports": "^1.0.3",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.1.2",
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "vite": "^4.2.0",
     "vite-tsconfig-paths": "^3.6.0"
   },

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -48,7 +48,7 @@
     "is-wsl": "^2.2.0",
     "rimraf": "^4.4.0",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "unbuild": "^1.1.2"
   }
 }

--- a/frameworks/preact/package.json
+++ b/frameworks/preact/package.json
@@ -29,7 +29,7 @@
     "@previewjs/storybook-helpers": "^1.0.3",
     "@previewjs/type-analyzer": "^6.0.4",
     "@previewjs/vfs": "^2.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@playwright/test": "~1.29.2",

--- a/frameworks/preact/tests/apps/preact-ts/package.json
+++ b/frameworks/preact/tests/apps/preact-ts/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "preact-cli": "^3.4.5",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   }
 }

--- a/frameworks/preact/tests/apps/storybook-js/package.json
+++ b/frameworks/preact/tests/apps/storybook-js/package.json
@@ -31,6 +31,6 @@
   },
   "dependencies": {
     "preact": "^10.13.0",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   }
 }

--- a/frameworks/preact/tests/apps/storybook-ts/package.json
+++ b/frameworks/preact/tests/apps/storybook-ts/package.json
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "@storybook/preact": "^6.5.16",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   }
 }

--- a/frameworks/preact/tests/apps/vite-preact/package.json
+++ b/frameworks/preact/tests/apps/vite-preact/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.5.0",
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "vite": "^4.1.4"
   }
 }

--- a/frameworks/react/package.json
+++ b/frameworks/react/package.json
@@ -30,7 +30,7 @@
     "@previewjs/type-analyzer": "^6.0.4",
     "@previewjs/vfs": "^2.0.1",
     "@vitejs/plugin-react": "^3.1.0",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@playwright/test": "~1.29.2",

--- a/frameworks/react/tests/apps/aliases/package.json
+++ b/frameworks/react/tests/apps/aliases/package.json
@@ -12,7 +12,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@babel/core": "^7.21.0",

--- a/frameworks/react/tests/apps/class-components-js/package.json
+++ b/frameworks/react/tests/apps/class-components-js/package.json
@@ -12,6 +12,6 @@
     "start": "react-scripts start"
   },
   "devDependencies": {
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   }
 }

--- a/frameworks/react/tests/apps/class-components-ts/package.json
+++ b/frameworks/react/tests/apps/class-components-ts/package.json
@@ -9,7 +9,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/frameworks/react/tests/apps/cra-css-modules-no-suffix/package.json
+++ b/frameworks/react/tests/apps/cra-css-modules-no-suffix/package.json
@@ -9,7 +9,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/frameworks/react/tests/apps/cra-css-modules/package.json
+++ b/frameworks/react/tests/apps/cra-css-modules/package.json
@@ -9,7 +9,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/frameworks/react/tests/apps/cra-custom-svgr/package.json
+++ b/frameworks/react/tests/apps/cra-custom-svgr/package.json
@@ -12,7 +12,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@previewjs/config": "workspace:*",

--- a/frameworks/react/tests/apps/cra-emotion-react16/package.json
+++ b/frameworks/react/tests/apps/cra-emotion-react16/package.json
@@ -11,7 +11,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/frameworks/react/tests/apps/cra-emotion/package.json
+++ b/frameworks/react/tests/apps/cra-emotion/package.json
@@ -11,7 +11,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/frameworks/react/tests/apps/cra-js/package.json
+++ b/frameworks/react/tests/apps/cra-js/package.json
@@ -11,6 +11,6 @@
     "start": "react-scripts start"
   },
   "devDependencies": {
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   }
 }

--- a/frameworks/react/tests/apps/cra-jsx/package.json
+++ b/frameworks/react/tests/apps/cra-jsx/package.json
@@ -11,6 +11,6 @@
     "start": "react-scripts start"
   },
   "devDependencies": {
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   }
 }

--- a/frameworks/react/tests/apps/cra-less/package.json
+++ b/frameworks/react/tests/apps/cra-less/package.json
@@ -13,7 +13,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "customize-cra": "^1.0.0",

--- a/frameworks/react/tests/apps/cra-react-router/package.json
+++ b/frameworks/react/tests/apps/cra-react-router/package.json
@@ -10,7 +10,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^5.3.4",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/frameworks/react/tests/apps/cra-sass-modules-no-suffix/package.json
+++ b/frameworks/react/tests/apps/cra-sass-modules-no-suffix/package.json
@@ -10,7 +10,7 @@
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
     "sass": "^1.58.3",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/frameworks/react/tests/apps/cra-sass-modules/package.json
+++ b/frameworks/react/tests/apps/cra-sass-modules/package.json
@@ -10,7 +10,7 @@
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
     "sass": "^1.58.3",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/frameworks/react/tests/apps/cra-sass/package.json
+++ b/frameworks/react/tests/apps/cra-sass/package.json
@@ -11,7 +11,7 @@
     "react-scripts": "^5.0.1",
     "sass": "^1.58.3",
     "sass-mq": "^6.0.0",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/frameworks/react/tests/apps/cra-storybook-ts/package.json
+++ b/frameworks/react/tests/apps/cra-storybook-ts/package.json
@@ -9,7 +9,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frameworks/react/tests/apps/cra-styled-components/package.json
+++ b/frameworks/react/tests/apps/cra-styled-components/package.json
@@ -11,7 +11,7 @@
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
     "styled-components": "^5.3.8",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/frameworks/react/tests/apps/cra-suspense/package.json
+++ b/frameworks/react/tests/apps/cra-suspense/package.json
@@ -11,6 +11,6 @@
     "start": "react-scripts start"
   },
   "devDependencies": {
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   }
 }

--- a/frameworks/react/tests/apps/cra-svgr/package.json
+++ b/frameworks/react/tests/apps/cra-svgr/package.json
@@ -12,7 +12,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@previewjs/config": "workspace:*",

--- a/frameworks/react/tests/apps/cra-tailwind-postcsscjs/package.json
+++ b/frameworks/react/tests/apps/cra-tailwind-postcsscjs/package.json
@@ -13,7 +13,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@craco/craco": "^7.0.0",

--- a/frameworks/react/tests/apps/cra-tailwind-postcssts/package.json
+++ b/frameworks/react/tests/apps/cra-tailwind-postcssts/package.json
@@ -12,7 +12,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@craco/craco": "^7.0.0",

--- a/frameworks/react/tests/apps/cra-tailwind/package.json
+++ b/frameworks/react/tests/apps/cra-tailwind/package.json
@@ -12,7 +12,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@craco/craco": "^7.0.0",

--- a/frameworks/react/tests/apps/cra-ts-react16/package.json
+++ b/frameworks/react/tests/apps/cra-ts-react16/package.json
@@ -9,7 +9,7 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/frameworks/react/tests/apps/cra-ts-react18/package.json
+++ b/frameworks/react/tests/apps/cra-ts-react18/package.json
@@ -9,7 +9,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/frameworks/react/tests/apps/cra-ts/package.json
+++ b/frameworks/react/tests/apps/cra-ts/package.json
@@ -9,7 +9,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/frameworks/react/tests/apps/imported-types/package.json
+++ b/frameworks/react/tests/apps/imported-types/package.json
@@ -9,7 +9,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/frameworks/react/tests/apps/material-ui/package.json
+++ b/frameworks/react/tests/apps/material-ui/package.json
@@ -16,7 +16,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/frameworks/react/tests/apps/nextjs-11/package.json
+++ b/frameworks/react/tests/apps/nextjs-11/package.json
@@ -14,6 +14,6 @@
     "@babel/core": "^7.21.0",
     "@previewjs/config-helper-nextjs": "workspace:*",
     "@types/react": "^18.0.28",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   }
 }

--- a/frameworks/react/tests/apps/nextjs-12/package.json
+++ b/frameworks/react/tests/apps/nextjs-12/package.json
@@ -14,6 +14,6 @@
     "@babel/core": "^7.21.0",
     "@previewjs/config-helper-nextjs": "workspace:*",
     "@types/react": "^18.0.28",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   }
 }

--- a/frameworks/react/tests/apps/nextjs-13/package.json
+++ b/frameworks/react/tests/apps/nextjs-13/package.json
@@ -12,7 +12,7 @@
     "next": "^13.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@previewjs/config-helper-nextjs": "workspace:*"

--- a/frameworks/react/tests/apps/storybook-js/package.json
+++ b/frameworks/react/tests/apps/storybook-js/package.json
@@ -35,6 +35,6 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   }
 }

--- a/frameworks/react/tests/apps/vite-tailwind/package.json
+++ b/frameworks/react/tests/apps/vite-tailwind/package.json
@@ -15,7 +15,7 @@
     "autoprefixer": "^10.4.13",
     "postcss": "^8.4.21",
     "tailwindcss": "^3.2.7",
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "vite": "^4.1.4",
     "vite-plugin-svgr": "^2.4.0"
   }

--- a/frameworks/react/tests/apps/vite-ts-react-swc/package.json
+++ b/frameworks/react/tests/apps/vite-ts-react-swc/package.json
@@ -14,7 +14,7 @@
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react-swc": "^3.2.0",
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "vite": "^4.1.4"
   }
 }

--- a/frameworks/react/tests/apps/vite-vanilla-extract/package.json
+++ b/frameworks/react/tests/apps/vite-vanilla-extract/package.json
@@ -7,7 +7,7 @@
     "@types/react-dom": "^18.0.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "vite"

--- a/frameworks/react/tests/apps/vite-with-svgr/package.json
+++ b/frameworks/react/tests/apps/vite-with-svgr/package.json
@@ -7,7 +7,7 @@
     "@types/react-dom": "^18.0.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "vite"

--- a/frameworks/react/tests/apps/vite-without-svgr/package.json
+++ b/frameworks/react/tests/apps/vite-without-svgr/package.json
@@ -7,7 +7,7 @@
     "@types/react-dom": "^18.0.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "vite"

--- a/frameworks/react/tests/apps/wrapper-custom-esm/package.json
+++ b/frameworks/react/tests/apps/wrapper-custom-esm/package.json
@@ -13,7 +13,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@babel/core": "^7.21.0",

--- a/frameworks/react/tests/apps/wrapper-custom/package.json
+++ b/frameworks/react/tests/apps/wrapper-custom/package.json
@@ -12,7 +12,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@babel/core": "^7.21.0",

--- a/frameworks/react/tests/apps/wrapper-default/package.json
+++ b/frameworks/react/tests/apps/wrapper-default/package.json
@@ -9,7 +9,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "start": "react-scripts start"

--- a/frameworks/solid/package.json
+++ b/frameworks/solid/package.json
@@ -31,7 +31,7 @@
     "@previewjs/storybook-helpers": "^1.0.3",
     "@previewjs/type-analyzer": "^6.0.4",
     "@previewjs/vfs": "^2.0.1",
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "vite-plugin-solid": "^2.6.1"
   },
   "devDependencies": {

--- a/frameworks/solid/src/extract-component.ts
+++ b/frameworks/solid/src/extract-component.ts
@@ -6,7 +6,7 @@ import {
   extractDefaultComponent,
   resolveComponent,
 } from "@previewjs/storybook-helpers";
-import { helpers, TypeResolver, UNKNOWN_TYPE } from "@previewjs/type-analyzer";
+import { TypeResolver, UNKNOWN_TYPE, helpers } from "@previewjs/type-analyzer";
 import ts from "typescript";
 import { analyzeSolidComponent } from "./analyze-component.js";
 

--- a/frameworks/solid/tests/apps/solid-ts/package.json
+++ b/frameworks/solid/tests/apps/solid-ts/package.json
@@ -5,7 +5,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "vite": "^4.1.4",
     "vite-plugin-solid": "^2.6.1"
   },

--- a/frameworks/solid/tests/apps/solidstart-bare-ssr/package.json
+++ b/frameworks/solid/tests/apps/solidstart-bare-ssr/package.json
@@ -9,7 +9,7 @@
     "esbuild": "^0.14.54",
     "postcss": "^8.4.21",
     "solid-start-node": "^0.2.23",
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "vite": "^3.2.5"
   },
   "dependencies": {

--- a/frameworks/svelte/package.json
+++ b/frameworks/svelte/package.json
@@ -32,7 +32,7 @@
     "@sveltejs/vite-plugin-svelte": "^2.0.3",
     "fs-extra": "^11.1.0",
     "svelte": "^3.57.0",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@playwright/test": "~1.29.2",

--- a/frameworks/vue2/package.json
+++ b/frameworks/vue2/package.json
@@ -33,7 +33,7 @@
     "@vitejs/plugin-vue2": "^2.2.0",
     "@vitejs/plugin-vue2-jsx": "^1.1.0",
     "fs-extra": "^11.1.0",
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "vue": "^2.7.14",
     "vue-template-compiler": "^2.7.14"
   },

--- a/frameworks/vue3/package.json
+++ b/frameworks/vue3/package.json
@@ -33,7 +33,7 @@
     "@vitejs/plugin-vue-jsx": "^3.0.1",
     "@vue/compiler-sfc": "^3.2.47",
     "fs-extra": "^11.1.0",
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "vue": "^3.2.47"
   },
   "devDependencies": {

--- a/iframe/package.json
+++ b/iframe/package.json
@@ -22,7 +22,7 @@
     "build": "tsc && unbuild"
   },
   "devDependencies": {
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "unbuild": "^1.1.2",
     "vite": "^4.2.0"
   }

--- a/integrations/cli/package.json
+++ b/integrations/cli/package.json
@@ -36,7 +36,7 @@
     "open": "^8.4.2",
     "rimraf": "^4.4.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "engines": {
     "node": "^14.18.0 || >=16.0.0"

--- a/integrations/intellij/daemon/package.json
+++ b/integrations/intellij/daemon/package.json
@@ -23,6 +23,6 @@
     "esbuild": "^0.17.12",
     "rimraf": "^4.4.0",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   }
 }

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -104,7 +104,7 @@
     "ovsx": "^0.8.0",
     "rimraf": "^4.4.0",
     "strip-ansi": "^7.0.1",
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "vsce": "^2.15.0"
   }
 }

--- a/loader/package.json
+++ b/loader/package.json
@@ -53,6 +53,6 @@
     "pnpm": "^7.30.0",
     "proper-lockfile": "^4.1.2",
     "rimraf": "^4.4.0",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prettier": "^2.8.4",
     "ts-node": "^10.9.1",
     "turbo": "^1.8.3",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "packageManager": "pnpm@7.30.0",
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,13 +21,13 @@ importers:
       prettier: ^2.8.4
       ts-node: ^10.9.1
       turbo: ^1.8.3
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     devDependencies:
       '@types/inquirer': 9.0.3
       '@types/license-checker': 25.0.3
       '@types/node': 18.15.3
-      '@typescript-eslint/eslint-plugin': 5.55.0_qsnvknysi52qtaxqdyqyohkcku
-      '@typescript-eslint/parser': 5.55.0_j4766f7ecgqbon3u7zlxn5zszu
+      '@typescript-eslint/eslint-plugin': 5.55.0_342y7v4tc7ytrrysmit6jo4wri
+      '@typescript-eslint/parser': 5.55.0_vgl77cfdswitgr47lm5swmv43m
       assert-never: 1.2.1
       depcheck: 1.4.3
       eslint: 8.36.0
@@ -36,23 +36,23 @@ importers:
       inquirer: 9.1.5
       license-checker: 25.0.1
       prettier: 2.8.4
-      ts-node: 10.9.1_sxidjv3cojnrggmso45tj7hldi
+      ts-node: 10.9.1_cbfmry4sbbh4vatmdrsmatfg5a
       turbo: 1.8.3
-      typescript: 5.0.2
+      typescript: 4.9.5
 
   api:
     specifiers:
       '@previewjs/serializable-values': ^5.0.1
       '@previewjs/type-analyzer': ^6.0.4
       axios: ^1.3.4
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
     dependencies:
       '@previewjs/serializable-values': link:../serializable-values
       '@previewjs/type-analyzer': link:../type-analyzer
       axios: 1.3.4
     devDependencies:
-      typescript: 5.0.2
+      typescript: 4.9.5
       unbuild: 1.1.2
 
   app:
@@ -73,7 +73,7 @@ importers:
       cross-env: ^7.0.3
       express: ^4.18.2
       fs-extra: ^11.1.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
       vite: ^4.2.0
     dependencies:
@@ -94,7 +94,7 @@ importers:
       '@types/node': 18.15.3
       cross-env: 7.0.3
       fs-extra: 11.1.0
-      typescript: 5.0.2
+      typescript: 4.9.5
       unbuild: 1.1.2
       vite: 4.2.0_@types+node@18.15.3
 
@@ -109,7 +109,7 @@ importers:
       express: ^4.18.2
       playwright: ~1.29.2
       rimraf: ^4.4.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
       vite: ^4.2.0
     dependencies:
@@ -123,19 +123,19 @@ importers:
     devDependencies:
       '@types/express': 4.17.17
       rimraf: 4.4.0
-      typescript: 5.0.2
+      typescript: 4.9.5
       unbuild: 1.1.2
       vite: 4.2.0
 
   config:
     specifiers:
       '@types/node': ^18.15.3
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
       vite: ^4.2.0
     devDependencies:
       '@types/node': 18.15.3
-      typescript: 5.0.2
+      typescript: 4.9.5
       unbuild: 1.1.2
       vite: 4.2.0_@types+node@18.15.3
 
@@ -144,19 +144,19 @@ importers:
       '@types/react': ^18.0.28
       next: ^13.2.4
       react: ^18.2.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
     devDependencies:
       '@types/react': 18.0.28
       next: 13.2.4_6m24vuloj5ihw4zc5lbsktc4fu
       react: 18.2.0
-      typescript: 5.0.2
+      typescript: 4.9.5
       unbuild: 1.1.2
 
   core:
     specifiers:
       '@previewjs/api': ^9.0.2
-      '@previewjs/config': ^5.0.2
+      '@previewjs/config': ^4.9.5
       '@previewjs/iframe': ^8.0.1
       '@previewjs/serializable-values': ^5.0.1
       '@previewjs/type-analyzer': ^6.0.4
@@ -180,7 +180,7 @@ importers:
       shx: ^0.3.4
       ts-node: ^10.9.1
       tsconfig-paths: ^4.1.2
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
       vite: ^4.2.0
       vite-tsconfig-paths: ^3.6.0
@@ -204,9 +204,9 @@ importers:
       http-terminator: 3.2.0
       recrawl: 2.2.1
       rollup-plugin-friendly-type-imports: 1.0.3
-      ts-node: 10.9.1_sxidjv3cojnrggmso45tj7hldi
+      ts-node: 10.9.1_cbfmry4sbbh4vatmdrsmatfg5a
       tsconfig-paths: 4.1.2
-      typescript: 5.0.2
+      typescript: 4.9.5
       vite: 4.2.0_@types+node@18.15.3
       vite-tsconfig-paths: 3.6.0_vite@4.2.0
     devDependencies:
@@ -229,7 +229,7 @@ importers:
       is-wsl: ^2.2.0
       rimraf: ^4.4.0
       ts-node-dev: ^2.0.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
     devDependencies:
       '@previewjs/api': link:../api
@@ -240,8 +240,8 @@ importers:
       exit-hook: 3.2.0
       is-wsl: 2.2.0
       rimraf: 4.4.0
-      ts-node-dev: 2.0.0_sxidjv3cojnrggmso45tj7hldi
-      typescript: 5.0.2
+      ts-node-dev: 2.0.0_cbfmry4sbbh4vatmdrsmatfg5a
+      typescript: 4.9.5
       unbuild: 1.1.2
 
   dev-workspace:
@@ -280,7 +280,7 @@ importers:
       '@previewjs/vfs': ^2.0.1
       preact: ^10.13.1
       rimraf: ^4.4.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
       vite: ^4.2.0
       vitest: ^0.29.3
@@ -289,7 +289,7 @@ importers:
       '@previewjs/storybook-helpers': link:../../storybook-helpers
       '@previewjs/type-analyzer': link:../../type-analyzer
       '@previewjs/vfs': link:../../vfs
-      typescript: 5.0.2
+      typescript: 4.9.5
     devDependencies:
       '@playwright/test': 1.29.2
       '@previewjs/api': link:../../api
@@ -318,14 +318,14 @@ importers:
       preact-cli: ^3.4.5
       preact-render-to-string: ^5.2.6
       preact-router: ^4.1.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       preact: 10.13.0
       preact-render-to-string: 5.2.6_preact@10.13.0
       preact-router: 4.1.0_preact@10.13.0
     devDependencies:
       preact-cli: 3.4.5_ezb4o27wyx2e45kiwfxxpbwliu
-      typescript: 5.0.2
+      typescript: 4.9.5
 
   frameworks/preact/tests/apps/storybook-js:
     specifiers:
@@ -338,19 +338,19 @@ importers:
       '@storybook/react': ^6.5.16
       babel-loader: ^9.1.2
       preact: ^10.13.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       webpack: ^5.75.0
     dependencies:
       preact: 10.13.0
-      typescript: 5.0.2
+      typescript: 4.9.5
     devDependencies:
       '@babel/core': 7.21.0
       '@storybook/addon-actions': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/addon-essentials': 6.5.16_hfwszvac5v5nztba6qrg5tyeki
+      '@storybook/addon-essentials': 6.5.16_pjt3hb2y6xt75f6zm5wytgwtvi
       '@storybook/addon-links': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/node-logger': 6.5.16
-      '@storybook/preset-create-react-app': 4.1.2_b6hd63vudugzmab4punuebqooe
-      '@storybook/react': 6.5.16_oo3vr6vtphws3bgkmzazea5rvu
+      '@storybook/preset-create-react-app': 4.1.2_jrqet27rlm2lmiqxjnwoky54w4
+      '@storybook/react': 6.5.16_atbdn65bs3jled2mkfe5k6i2ka
       babel-loader: 9.1.2_qoaxtqicpzj5p3ubthw53xafqm
       webpack: 5.75.0
 
@@ -358,24 +358,24 @@ importers:
     specifiers:
       '@storybook/preact': ^6.5.16
       preact: ^10.13.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       preact: 10.13.0
     devDependencies:
-      '@storybook/preact': 6.5.16_ymutfbf23ptyofokmjee4ypvem
-      typescript: 5.0.2
+      '@storybook/preact': 6.5.16_4pbvjs5xcqoa4t5hqii55vh5ei
+      typescript: 4.9.5
 
   frameworks/preact/tests/apps/vite-preact:
     specifiers:
       '@preact/preset-vite': ^2.5.0
       preact: ^10.13.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       vite: ^4.1.4
     dependencies:
       preact: 10.13.0
     devDependencies:
       '@preact/preset-vite': 2.5.0_wzm33zgg7fxctdv5dfqx47n7y4
-      typescript: 5.0.2
+      typescript: 4.9.5
       vite: 4.1.4
 
   frameworks/react:
@@ -395,7 +395,7 @@ importers:
       '@vitejs/plugin-react': ^3.1.0
       concurrently: ^7.6.0
       react: ^18.2.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
       vite: ^4.2.0
       vitest: ^0.29.3
@@ -405,7 +405,7 @@ importers:
       '@previewjs/type-analyzer': link:../../type-analyzer
       '@previewjs/vfs': link:../../vfs
       '@vitejs/plugin-react': 3.1.0_vite@4.2.0
-      typescript: 5.0.2
+      typescript: 4.9.5
     devDependencies:
       '@playwright/test': 1.29.2
       '@previewjs/api': link:../../api
@@ -448,7 +448,7 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       vite-plugin-react-svgr: ^1.0.1
     dependencies:
       '@types/node': 18.14.6
@@ -456,8 +456,8 @@ importers:
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
     devDependencies:
       '@babel/core': 7.21.0
       '@previewjs/config': link:../../../../../config
@@ -482,14 +482,14 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
     devDependencies:
-      typescript: 5.0.2
+      typescript: 4.9.5
 
   frameworks/react/tests/apps/class-components-ts:
     specifiers:
@@ -499,15 +499,15 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
 
   frameworks/react/tests/apps/cra-css-modules:
     specifiers:
@@ -517,15 +517,15 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
 
   frameworks/react/tests/apps/cra-css-modules-no-suffix:
     specifiers:
@@ -535,15 +535,15 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
 
   frameworks/react/tests/apps/cra-custom-svgr:
     specifiers:
@@ -555,7 +555,7 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       vite-plugin-react-svgr: ^1.0.1
     dependencies:
       '@types/node': 18.14.6
@@ -563,8 +563,8 @@ importers:
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
     devDependencies:
       '@previewjs/config': link:../../../../../config
       '@previewjs/plugin-react': link:../../..
@@ -581,7 +581,7 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@emotion/react': 11.10.6_pmekkgnqduwlme35zpnqhenc34
       '@emotion/styled': 11.10.6_oouaibmszuch5k64ms7uxp2aia
@@ -590,8 +590,8 @@ importers:
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
     devDependencies:
       '@babel/core': 7.21.0
 
@@ -606,7 +606,7 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@emotion/react': 11.10.6_pmekkgnqduwlme35zpnqhenc34
       '@emotion/styled': 11.10.6_oouaibmszuch5k64ms7uxp2aia
@@ -615,8 +615,8 @@ importers:
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
     devDependencies:
       '@babel/core': 7.21.0
 
@@ -625,26 +625,26 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
     devDependencies:
-      typescript: 5.0.2
+      typescript: 4.9.5
 
   frameworks/react/tests/apps/cra-jsx:
     specifiers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
     devDependencies:
-      typescript: 5.0.2
+      typescript: 4.9.5
 
   frameworks/react/tests/apps/cra-less:
     specifiers:
@@ -658,7 +658,7 @@ importers:
       react-app-rewired: ^2.2.1
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       webpack: ^5.75.0
     dependencies:
       '@types/node': 18.14.6
@@ -667,8 +667,8 @@ importers:
       less: 4.1.3
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
     devDependencies:
       customize-cra: 1.0.0
       less-loader: 11.1.0_less@4.1.3+webpack@5.75.0
@@ -685,7 +685,7 @@ importers:
       react-dom: ^18.2.0
       react-router-dom: ^5.3.4
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
@@ -693,8 +693,8 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-router-dom: 5.3.4_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
     devDependencies:
       '@types/react-router-dom': 5.3.3
 
@@ -708,17 +708,17 @@ importers:
       react-scripts: ^5.0.1
       sass: ^1.58.3
       sass-mq: ^6.0.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_dpztdo7g75ohhwxcrpfkjai7wm
+      react-scripts: 5.0.1_z7cyyy7aniencsdruwwbt2kbhm
       sass: 1.58.3
       sass-mq: 6.0.0
-      typescript: 5.0.2
+      typescript: 4.9.5
 
   frameworks/react/tests/apps/cra-sass-modules:
     specifiers:
@@ -729,16 +729,16 @@ importers:
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
       sass: ^1.58.3
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_dpztdo7g75ohhwxcrpfkjai7wm
+      react-scripts: 5.0.1_z7cyyy7aniencsdruwwbt2kbhm
       sass: 1.58.3
-      typescript: 5.0.2
+      typescript: 4.9.5
 
   frameworks/react/tests/apps/cra-sass-modules-no-suffix:
     specifiers:
@@ -749,16 +749,16 @@ importers:
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
       sass: ^1.58.3
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_dpztdo7g75ohhwxcrpfkjai7wm
+      react-scripts: 5.0.1_z7cyyy7aniencsdruwwbt2kbhm
       sass: 1.58.3
-      typescript: 5.0.2
+      typescript: 4.9.5
 
   frameworks/react/tests/apps/cra-storybook-js:
     specifiers:
@@ -817,7 +817,7 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       webpack: ^5.75.0
     dependencies:
       '@types/node': 18.14.6
@@ -825,18 +825,18 @@ importers:
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
     devDependencies:
       '@storybook/addon-actions': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/addon-essentials': 6.5.16_4jos2hkjffysotdcartp3chmka
-      '@storybook/addon-interactions': 6.5.16_bspqkkbxkxndypqd5swcfjhx6u
+      '@storybook/addon-essentials': 6.5.16_7wnuxxaq2huqt75wbco3e7j4ba
+      '@storybook/addon-interactions': 6.5.16_qt7jxhik3le2qutqteepi444bi
       '@storybook/addon-links': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/builder-webpack5': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/manager-webpack5': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
+      '@storybook/builder-webpack5': 6.5.16_gpdukexrhjgu66opmh7iixboiu
+      '@storybook/manager-webpack5': 6.5.16_gpdukexrhjgu66opmh7iixboiu
       '@storybook/node-logger': 6.5.16
-      '@storybook/preset-create-react-app': 4.1.2_b6hd63vudugzmab4punuebqooe
-      '@storybook/react': 6.5.16_7uctrkj2ghraftlvfygs5kxbxi
+      '@storybook/preset-create-react-app': 4.1.2_jrqet27rlm2lmiqxjnwoky54w4
+      '@storybook/react': 6.5.16_4obprv6wy6yhlizylxwk4rs74a
       '@storybook/testing-library': 0.0.13_biqbaboplfbrettd7655fr4n2y
       babel-plugin-named-exports-order: 0.0.2
       prop-types: 15.8.1
@@ -853,7 +853,7 @@ importers:
       react-is: ^18.2.0
       react-scripts: ^5.0.1
       styled-components: ^5.3.8
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
@@ -861,9 +861,9 @@ importers:
       '@types/styled-components': 5.1.26
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
       styled-components: 5.3.8_7i5myeigehqah43i5u7wbekgba
-      typescript: 5.0.2
+      typescript: 4.9.5
     devDependencies:
       react-is: 18.2.0
 
@@ -872,13 +872,13 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
     devDependencies:
-      typescript: 5.0.2
+      typescript: 4.9.5
 
   frameworks/react/tests/apps/cra-svgr:
     specifiers:
@@ -890,7 +890,7 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       vite-plugin-react-svgr: ^1.0.1
     dependencies:
       '@types/node': 18.14.6
@@ -898,8 +898,8 @@ importers:
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
     devDependencies:
       '@previewjs/config': link:../../../../../config
       '@previewjs/plugin-react': link:../../..
@@ -917,17 +917,17 @@ importers:
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
       tailwindcss: ^3.2.7
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
     devDependencies:
-      '@craco/craco': 7.0.0_eoacngllklz4ocdw2sdpspzhxa
+      '@craco/craco': 7.0.0_hbpkpx3bwnq5tcaqzhwltd7uye
       autoprefixer: 10.4.13_postcss@8.4.21
       postcss: 8.4.21
       tailwindcss: 3.2.7_postcss@8.4.21
@@ -944,17 +944,17 @@ importers:
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
       tailwindcss: ^3.2.7
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
     devDependencies:
-      '@craco/craco': 7.0.0_eoacngllklz4ocdw2sdpspzhxa
+      '@craco/craco': 7.0.0_hbpkpx3bwnq5tcaqzhwltd7uye
       autoprefixer: 10.4.13_postcss@8.4.21
       postcss: 8.4.21
       tailwindcss: 3.2.7_postcss@8.4.21
@@ -971,17 +971,17 @@ importers:
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
       tailwindcss: ^3.2.7
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
     devDependencies:
-      '@craco/craco': 7.0.0_eoacngllklz4ocdw2sdpspzhxa
+      '@craco/craco': 7.0.0_hbpkpx3bwnq5tcaqzhwltd7uye
       autoprefixer: 10.4.13_postcss@8.4.21
       postcss: 8.4.21
       tailwindcss: 3.2.7_postcss@8.4.21
@@ -994,15 +994,15 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
 
   frameworks/react/tests/apps/cra-ts-react16:
     specifiers:
@@ -1012,15 +1012,15 @@ importers:
       react: ^16.14.0
       react-dom: ^16.14.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 16.14.35
       '@types/react-dom': 16.9.18
       react: 16.14.0
       react-dom: 16.14.0_react@16.14.0
-      react-scripts: 5.0.1_yi7pi2hxako6ihbutpjt7r7sjq
-      typescript: 5.0.2
+      react-scripts: 5.0.1_qmzmvk5l77gjs3zzl3vdy6ploi
+      typescript: 4.9.5
 
   frameworks/react/tests/apps/cra-ts-react18:
     specifiers:
@@ -1030,15 +1030,15 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
 
   frameworks/react/tests/apps/imported-types:
     specifiers:
@@ -1048,15 +1048,15 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
 
   frameworks/react/tests/apps/material-ui:
     specifiers:
@@ -1075,7 +1075,7 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@emotion/react': 11.10.6_pmekkgnqduwlme35zpnqhenc34
       '@emotion/styled': 11.10.6_oouaibmszuch5k64ms7uxp2aia
@@ -1089,8 +1089,8 @@ importers:
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
     devDependencies:
       '@babel/core': 7.21.0
       prop-types: 15.8.1
@@ -1103,16 +1103,16 @@ importers:
       next: ^11.1.4
       react: ^18.2.0
       react-dom: ^18.2.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
-      next: 11.1.4_naxqhzibi624xxsjqpijhf76xq
+      next: 11.1.4_6mbplxbx6s7x4hmdmervij2kcu
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
       '@babel/core': 7.21.0
       '@previewjs/config-helper-nextjs': link:../../../../../config-helpers/nextjs
       '@types/react': 18.0.28
-      typescript: 5.0.2
+      typescript: 4.9.5
 
   frameworks/react/tests/apps/nextjs-12:
     specifiers:
@@ -1122,7 +1122,7 @@ importers:
       next: ^12.3.4
       react: ^18.2.0
       react-dom: ^18.2.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       next: 12.3.4_6m24vuloj5ihw4zc5lbsktc4fu
       react: 18.2.0
@@ -1131,7 +1131,7 @@ importers:
       '@babel/core': 7.21.0
       '@previewjs/config-helper-nextjs': link:../../../../../config-helpers/nextjs
       '@types/react': 18.0.28
-      typescript: 5.0.2
+      typescript: 4.9.5
 
   frameworks/react/tests/apps/nextjs-13:
     specifiers:
@@ -1142,7 +1142,7 @@ importers:
       next: ^13.2.3
       react: ^18.2.0
       react-dom: ^18.2.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
@@ -1150,7 +1150,7 @@ importers:
       next: 13.2.3_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      typescript: 5.0.2
+      typescript: 4.9.5
     devDependencies:
       '@previewjs/config-helper-nextjs': link:../../../../../config-helpers/nextjs
 
@@ -1272,24 +1272,24 @@ importers:
       react-dom: ^18.2.0
       react-refresh: ^0.14.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       webpack: ^5.75.0
     dependencies:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      typescript: 5.0.2
+      typescript: 4.9.5
     devDependencies:
       '@babel/core': 7.21.0
       '@storybook/addon-actions': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/addon-essentials': 6.5.16_hfwszvac5v5nztba6qrg5tyeki
+      '@storybook/addon-essentials': 6.5.16_pjt3hb2y6xt75f6zm5wytgwtvi
       '@storybook/addon-links': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/node-logger': 6.5.16
-      '@storybook/preset-create-react-app': 4.1.2_b6hd63vudugzmab4punuebqooe
-      '@storybook/react': 6.5.16_oo3vr6vtphws3bgkmzazea5rvu
+      '@storybook/preset-create-react-app': 4.1.2_jrqet27rlm2lmiqxjnwoky54w4
+      '@storybook/react': 6.5.16_atbdn65bs3jled2mkfe5k6i2ka
       babel-loader: 9.1.2_qoaxtqicpzj5p3ubthw53xafqm
       react-refresh: 0.14.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
       webpack: 5.75.0
 
   frameworks/react/tests/apps/vite-tailwind:
@@ -1302,7 +1302,7 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       tailwindcss: ^3.2.7
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       vite: ^4.1.4
       vite-plugin-svgr: ^2.4.0
     dependencies:
@@ -1315,7 +1315,7 @@ importers:
       autoprefixer: 10.4.13_postcss@8.4.21
       postcss: 8.4.21
       tailwindcss: 3.2.7_postcss@8.4.21
-      typescript: 5.0.2
+      typescript: 4.9.5
       vite: 4.1.4
       vite-plugin-svgr: 2.4.0_vite@4.1.4
 
@@ -1326,7 +1326,7 @@ importers:
       '@vitejs/plugin-react-swc': ^3.2.0
       react: ^18.2.0
       react-dom: ^18.2.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       vite: ^4.1.4
     dependencies:
       react: 18.2.0
@@ -1335,7 +1335,7 @@ importers:
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       '@vitejs/plugin-react-swc': 3.2.0_vite@4.1.4
-      typescript: 5.0.2
+      typescript: 4.9.5
       vite: 4.1.4
 
   frameworks/react/tests/apps/vite-vanilla-extract:
@@ -1348,14 +1348,14 @@ importers:
       '@vitejs/plugin-react': ^3.1.0
       react: ^18.2.0
       react-dom: ^18.2.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       vite: ^4.1.4
     dependencies:
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      typescript: 5.0.2
+      typescript: 4.9.5
     devDependencies:
       '@previewjs/config': link:../../../../../config
       '@vanilla-extract/css': 1.9.5
@@ -1370,7 +1370,7 @@ importers:
       '@vitejs/plugin-react': ^3.1.0
       react: ^18.2.0
       react-dom: ^18.2.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       vite: ^4.1.4
       vite-plugin-svgr: ^2.4.0
     dependencies:
@@ -1378,7 +1378,7 @@ importers:
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      typescript: 5.0.2
+      typescript: 4.9.5
     devDependencies:
       '@vitejs/plugin-react': 3.1.0_vite@4.1.4
       vite: 4.1.4
@@ -1391,14 +1391,14 @@ importers:
       '@vitejs/plugin-react': ^3.1.0
       react: ^18.2.0
       react-dom: ^18.2.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       vite: ^4.1.4
     dependencies:
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      typescript: 5.0.2
+      typescript: 4.9.5
     devDependencies:
       '@vitejs/plugin-react': 3.1.0_vite@4.1.4
       vite: 4.1.4
@@ -1413,18 +1413,18 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
     devDependencies:
       '@babel/core': 7.21.0
-      '@previewjs/config': 4.0.3
+      '@previewjs/config': link:../../../../../config
 
   frameworks/react/tests/apps/wrapper-custom-esm:
     specifiers:
@@ -1436,18 +1436,18 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
     devDependencies:
       '@babel/core': 7.21.0
-      '@previewjs/config': 4.0.3
+      '@previewjs/config': link:../../../../../config
 
   frameworks/react/tests/apps/wrapper-default:
     specifiers:
@@ -1458,15 +1458,15 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-scripts: ^5.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     dependencies:
       '@types/node': 18.14.6
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      typescript: 5.0.2
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
+      typescript: 4.9.5
     devDependencies:
       '@babel/core': 7.21.0
 
@@ -1480,7 +1480,7 @@ importers:
       '@previewjs/type-analyzer': ^6.0.4
       '@previewjs/vfs': ^2.0.1
       solid-js: ^1.6.15
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
       vite: ^4.2.0
       vite-plugin-solid: ^2.6.1
@@ -1490,7 +1490,7 @@ importers:
       '@previewjs/storybook-helpers': link:../../storybook-helpers
       '@previewjs/type-analyzer': link:../../type-analyzer
       '@previewjs/vfs': link:../../vfs
-      typescript: 5.0.2
+      typescript: 4.9.5
       vite-plugin-solid: 2.6.1_solid-js@1.6.15+vite@4.2.0
     devDependencies:
       '@playwright/test': 1.29.2
@@ -1537,13 +1537,13 @@ importers:
   frameworks/solid/tests/apps/solid-ts:
     specifiers:
       solid-js: ^1.6.12
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       vite: ^4.1.4
       vite-plugin-solid: ^2.6.1
     dependencies:
       solid-js: 1.6.12
     devDependencies:
-      typescript: 5.0.2
+      typescript: 4.9.5
       vite: 4.1.4
       vite-plugin-solid: 2.6.1_solid-js@1.6.12+vite@4.1.4
 
@@ -1557,7 +1557,7 @@ importers:
       solid-js: ^1.6.12
       solid-start: ^0.2.23
       solid-start-node: ^0.2.23
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       undici: ^5.20.0
       vite: ^3.2.5
     dependencies:
@@ -1571,7 +1571,7 @@ importers:
       esbuild: 0.14.54
       postcss: 8.4.21
       solid-start-node: 0.2.23_f7gfu5z2y3sg6nmwa2esfziw54
-      typescript: 5.0.2
+      typescript: 4.9.5
       vite: 3.2.5_@types+node@18.14.6
 
   frameworks/svelte:
@@ -1587,7 +1587,7 @@ importers:
       '@types/fs-extra': ^11.0.1
       fs-extra: ^11.1.0
       svelte: ^3.57.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
       vite: ^4.2.0
       vitest: ^0.29.3
@@ -1599,7 +1599,7 @@ importers:
       '@sveltejs/vite-plugin-svelte': 2.0.3_svelte@3.57.0+vite@4.2.0
       fs-extra: 11.1.0
       svelte: 3.57.0
-      typescript: 5.0.2
+      typescript: 4.9.5
     devDependencies:
       '@playwright/test': 1.29.2
       '@previewjs/core': link:../../core
@@ -1718,7 +1718,7 @@ importers:
       '@vitejs/plugin-vue2': ^2.2.0
       '@vitejs/plugin-vue2-jsx': ^1.1.0
       fs-extra: ^11.1.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
       vite: ^4.2.0
       vitest: ^0.29.3
@@ -1733,7 +1733,7 @@ importers:
       '@vitejs/plugin-vue2': 2.2.0_vite@4.2.0+vue@2.7.14
       '@vitejs/plugin-vue2-jsx': 1.1.0_7kpbn5dxoij3qg7uznorvettde
       fs-extra: 11.1.0
-      typescript: 5.0.2
+      typescript: 4.9.5
       vue: 2.7.14
       vue-template-compiler: 2.7.14
     devDependencies:
@@ -1840,7 +1840,7 @@ importers:
       '@vitejs/plugin-vue-jsx': ^3.0.1
       '@vue/compiler-sfc': ^3.2.47
       fs-extra: ^11.1.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
       vite: ^4.2.0
       vitest: ^0.29.3
@@ -1854,7 +1854,7 @@ importers:
       '@vitejs/plugin-vue-jsx': 3.0.1_vite@4.2.0+vue@3.2.47
       '@vue/compiler-sfc': 3.2.47
       fs-extra: 11.1.0
-      typescript: 5.0.2
+      typescript: 4.9.5
       vue: 3.2.47
     devDependencies:
       '@playwright/test': 1.29.2
@@ -1927,11 +1927,11 @@ importers:
 
   iframe:
     specifiers:
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
       vite: ^4.2.0
     devDependencies:
-      typescript: 5.0.2
+      typescript: 4.9.5
       unbuild: 1.1.2
       vite: 4.2.0
 
@@ -1948,7 +1948,7 @@ importers:
       open: ^8.4.2
       rimraf: ^4.4.0
       ts-node: ^10.9.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     devDependencies:
       '@previewjs/api': link:../../api
       '@previewjs/loader': link:../../loader
@@ -1960,8 +1960,8 @@ importers:
       nodemon: 2.0.21
       open: 8.4.2
       rimraf: 4.4.0
-      ts-node: 10.9.1_sxidjv3cojnrggmso45tj7hldi
-      typescript: 5.0.2
+      ts-node: 10.9.1_cbfmry4sbbh4vatmdrsmatfg5a
+      typescript: 4.9.5
 
   integrations/intellij/daemon:
     specifiers:
@@ -1970,14 +1970,14 @@ importers:
       esbuild: ^0.17.12
       rimraf: ^4.4.0
       ts-node-dev: ^2.0.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     devDependencies:
       '@previewjs/daemon': link:../../../daemon
       '@previewjs/loader': link:../../../loader
       esbuild: 0.17.12
       rimraf: 4.4.0
-      ts-node-dev: 2.0.0_sxidjv3cojnrggmso45tj7hldi
-      typescript: 5.0.2
+      ts-node-dev: 2.0.0_cbfmry4sbbh4vatmdrsmatfg5a
+      typescript: 4.9.5
 
   integrations/vscode:
     specifiers:
@@ -1991,7 +1991,7 @@ importers:
       ovsx: ^0.8.0
       rimraf: ^4.4.0
       strip-ansi: ^7.0.1
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       vsce: ^2.15.0
     devDependencies:
       '@previewjs/daemon': link:../../daemon
@@ -2004,7 +2004,7 @@ importers:
       ovsx: 0.8.0
       rimraf: 4.4.0
       strip-ansi: 7.0.1
-      typescript: 5.0.2
+      typescript: 4.9.5
       vsce: 2.15.0
 
   loader:
@@ -2019,7 +2019,7 @@ importers:
       pnpm: ^7.30.0
       proper-lockfile: ^4.1.2
       rimraf: ^4.4.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
     devDependencies:
       '@previewjs/core': link:../core
       '@previewjs/vfs': link:../vfs
@@ -2031,13 +2031,13 @@ importers:
       pnpm: 7.30.0
       proper-lockfile: 4.1.2
       rimraf: 4.4.0
-      typescript: 5.0.2
+      typescript: 4.9.5
 
   properties:
     specifiers:
       '@previewjs/serializable-values': ^5.0.1
       '@previewjs/type-analyzer': ^6.0.4
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
       vite: ^4.2.0
       vitest: ^0.29.3
@@ -2045,7 +2045,7 @@ importers:
       '@previewjs/serializable-values': link:../serializable-values
       '@previewjs/type-analyzer': link:../type-analyzer
     devDependencies:
-      typescript: 5.0.2
+      typescript: 4.9.5
       unbuild: 1.1.2
       vite: 4.2.0
       vitest: 0.29.3
@@ -2057,7 +2057,7 @@ importers:
       '@types/prettier': ^2.7.2
       assert-never: ^1.2.1
       prettier: ^2.8.4
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
       vite: ^4.2.0
       vitest: ^0.29.3
@@ -2066,7 +2066,7 @@ importers:
       '@previewjs/type-analyzer': link:../type-analyzer
       assert-never: 1.2.1
       prettier: 2.8.4
-      typescript: 5.0.2
+      typescript: 4.9.5
     devDependencies:
       '@types/prettier': 2.7.2
       unbuild: 1.1.2
@@ -2079,7 +2079,7 @@ importers:
       '@previewjs/serializable-values': ^5.0.1
       '@previewjs/type-analyzer': ^6.0.4
       '@previewjs/vfs': workspace:*
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
       vite: ^4.2.0
       vitest: ^0.29.3
@@ -2087,7 +2087,7 @@ importers:
       '@previewjs/core': link:../core
       '@previewjs/serializable-values': link:../serializable-values
       '@previewjs/type-analyzer': link:../type-analyzer
-      typescript: 5.0.2
+      typescript: 4.9.5
     devDependencies:
       '@previewjs/vfs': link:../vfs
       unbuild: 1.1.2
@@ -2108,7 +2108,7 @@ importers:
       get-port: ^6.1.2
       playwright: ~1.29.2
       rimraf: ^4.4.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
     dependencies:
       '@playwright/test': 1.29.2
@@ -2124,7 +2124,7 @@ importers:
     devDependencies:
       '@types/fs-extra': 11.0.1
       rimraf: 4.4.0
-      typescript: 5.0.2
+      typescript: 4.9.5
       unbuild: 1.1.2
 
   type-analyzer:
@@ -2135,7 +2135,7 @@ importers:
       assert-never: ^1.2.1
       lodash: ^4.17.21
       prettier: ^2.8.4
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
       vite: ^4.2.0
       vitest: ^0.29.3
@@ -2143,7 +2143,7 @@ importers:
       '@previewjs/vfs': link:../vfs
       assert-never: 1.2.1
       prettier: 2.8.4
-      typescript: 5.0.2
+      typescript: 4.9.5
     devDependencies:
       '@types/lodash': 4.14.191
       '@types/prettier': 2.7.2
@@ -2158,7 +2158,7 @@ importers:
       assert-never: ^1.2.1
       chokidar: ^3.5.3
       fs-extra: ^11.1.0
-      typescript: ^5.0.2
+      typescript: ^4.9.5
       unbuild: ^1.1.2
       vite: ^4.2.0
       vitest: ^0.29.3
@@ -2168,7 +2168,7 @@ importers:
       fs-extra: 11.1.0
     devDependencies:
       '@types/fs-extra': 11.0.1
-      typescript: 5.0.2
+      typescript: 4.9.5
       unbuild: 1.1.2
       vite: 4.2.0
       vitest: 0.29.3
@@ -4042,7 +4042,7 @@ packages:
     dev: true
     optional: true
 
-  /@craco/craco/7.0.0_eoacngllklz4ocdw2sdpspzhxa:
+  /@craco/craco/7.0.0_hbpkpx3bwnq5tcaqzhwltd7uye:
     resolution: {integrity: sha512-OyjL9zpURB6Ha1HO62Hlt27Xd7UYJ8DRiBNuE4DBB8Ue0iQ9q/xsv3ze7ROm6gCZqV6I2Gxjnq0EHCCye+4xDQ==}
     engines: {node: '>=6'}
     hasBin: true
@@ -4051,10 +4051,10 @@ packages:
     dependencies:
       autoprefixer: 10.4.13_postcss@8.4.21
       cosmiconfig: 7.1.0
-      cosmiconfig-typescript-loader: 1.0.9_3ge77i23l64vl4dlqvwynlpyne
+      cosmiconfig-typescript-loader: 1.0.9_epm2eosjl5rrlyrsakgmxyecne
       cross-spawn: 7.0.3
       lodash: 4.17.21
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
       semver: 7.3.8
       webpack-merge: 5.8.0
     transitivePeerDependencies:
@@ -8782,40 +8782,6 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/addon-controls/6.5.16_3okg5sz67cj64fzm2duc7o3pe4:
-    resolution: {integrity: sha512-kShSGjq1MjmmyL3l8i+uPz6yddtf82mzys0l82VKtcuyjrr5944wYFJ5NTXMfZxrO/U6FeFsfuFZE/k6ex3EMg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-    dependencies:
-      '@storybook/addons': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/api': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/client-logger': 6.5.16
-      '@storybook/components': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-common': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/node-logger': 6.5.16
-      '@storybook/store': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/theming': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      core-js: 3.29.0
-      lodash: 4.17.21
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      ts-dedent: 2.2.0
-    transitivePeerDependencies:
-      - eslint
-      - supports-color
-      - typescript
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: true
-
   /@storybook/addon-controls/6.5.16_gpdukexrhjgu66opmh7iixboiu:
     resolution: {integrity: sha512-kShSGjq1MjmmyL3l8i+uPz6yddtf82mzys0l82VKtcuyjrr5944wYFJ5NTXMfZxrO/U6FeFsfuFZE/k6ex3EMg==}
     peerDependencies:
@@ -8846,61 +8812,6 @@ packages:
       - supports-color
       - typescript
       - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: true
-
-  /@storybook/addon-docs/6.5.16_hfwszvac5v5nztba6qrg5tyeki:
-    resolution: {integrity: sha512-QM9WDZG9P02UvbzLu947a8ZngOrQeAKAT8jCibQFM/+RJ39xBlfm8rm+cQy3dm94wgtjmVkA3mKGOV/yrrsddg==}
-    peerDependencies:
-      '@storybook/mdx2-csf': ^0.0.3
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-    peerDependenciesMeta:
-      '@storybook/mdx2-csf':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-    dependencies:
-      '@babel/plugin-transform-react-jsx': 7.21.0_@babel+core@7.21.0
-      '@babel/preset-env': 7.20.2_@babel+core@7.21.0
-      '@jest/transform': 26.6.2
-      '@mdx-js/react': 1.6.22_react@18.2.0
-      '@storybook/addons': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/api': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/components': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-common': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/core-events': 6.5.16
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/docs-tools': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/mdx1-csf': 0.0.1_@babel+core@7.21.0
-      '@storybook/node-logger': 6.5.16
-      '@storybook/postinstall': 6.5.16
-      '@storybook/preview-web': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/source-loader': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/store': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/theming': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      babel-loader: 8.3.0_qoaxtqicpzj5p3ubthw53xafqm
-      core-js: 3.29.0
-      fast-deep-equal: 3.1.3
-      global: 4.4.0
-      lodash: 4.17.21
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      regenerator-runtime: 0.13.11
-      remark-external-links: 8.0.0
-      remark-slug: 6.1.0
-      ts-dedent: 2.2.0
-      util-deprecate: 1.0.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - eslint
-      - supports-color
-      - typescript
-      - vue-template-compiler
-      - webpack
       - webpack-cli
       - webpack-command
     dev: true
@@ -8956,93 +8867,6 @@ packages:
       - typescript
       - vue-template-compiler
       - webpack
-      - webpack-cli
-      - webpack-command
-    dev: true
-
-  /@storybook/addon-essentials/6.5.16_4jos2hkjffysotdcartp3chmka:
-    resolution: {integrity: sha512-TeoMr6tEit4Pe91GH6f8g/oar1P4M0JL9S6oMcFxxrhhtOGO7XkWD5EnfyCx272Ok2VYfE58FNBTGPNBVIqYKQ==}
-    peerDependencies:
-      '@babel/core': ^7.9.6
-      '@storybook/angular': '*'
-      '@storybook/builder-manager4': '*'
-      '@storybook/builder-manager5': '*'
-      '@storybook/builder-webpack4': '*'
-      '@storybook/builder-webpack5': '*'
-      '@storybook/html': '*'
-      '@storybook/vue': '*'
-      '@storybook/vue3': '*'
-      '@storybook/web-components': '*'
-      lit: '*'
-      lit-html: '*'
-      react: '*'
-      react-dom: '*'
-      svelte: '*'
-      sveltedoc-parser: '*'
-      vue: '*'
-      webpack: '*'
-    peerDependenciesMeta:
-      '@storybook/angular':
-        optional: true
-      '@storybook/builder-manager4':
-        optional: true
-      '@storybook/builder-manager5':
-        optional: true
-      '@storybook/builder-webpack4':
-        optional: true
-      '@storybook/builder-webpack5':
-        optional: true
-      '@storybook/html':
-        optional: true
-      '@storybook/vue':
-        optional: true
-      '@storybook/vue3':
-        optional: true
-      '@storybook/web-components':
-        optional: true
-      lit:
-        optional: true
-      lit-html:
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-      svelte:
-        optional: true
-      sveltedoc-parser:
-        optional: true
-      vue:
-        optional: true
-      webpack:
-        optional: true
-    dependencies:
-      '@babel/core': 7.21.0
-      '@storybook/addon-actions': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/addon-backgrounds': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/addon-controls': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/addon-docs': 6.5.16_hfwszvac5v5nztba6qrg5tyeki
-      '@storybook/addon-measure': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/addon-outline': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/addon-toolbars': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/addon-viewport': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/addons': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/api': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/builder-webpack5': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/core-common': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/node-logger': 6.5.16
-      core-js: 3.29.0
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      regenerator-runtime: 0.13.11
-      ts-dedent: 2.2.0
-      webpack: 5.75.0
-    transitivePeerDependencies:
-      - '@storybook/mdx2-csf'
-      - eslint
-      - supports-color
-      - typescript
-      - vue-template-compiler
       - webpack-cli
       - webpack-command
     dev: true
@@ -9134,7 +8958,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-essentials/6.5.16_hfwszvac5v5nztba6qrg5tyeki:
+  /@storybook/addon-essentials/6.5.16_pjt3hb2y6xt75f6zm5wytgwtvi:
     resolution: {integrity: sha512-TeoMr6tEit4Pe91GH6f8g/oar1P4M0JL9S6oMcFxxrhhtOGO7XkWD5EnfyCx272Ok2VYfE58FNBTGPNBVIqYKQ==}
     peerDependencies:
       '@babel/core': ^7.9.6
@@ -9194,15 +9018,15 @@ packages:
       '@babel/core': 7.21.0
       '@storybook/addon-actions': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-backgrounds': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/addon-controls': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/addon-docs': 6.5.16_hfwszvac5v5nztba6qrg5tyeki
+      '@storybook/addon-controls': 6.5.16_gpdukexrhjgu66opmh7iixboiu
+      '@storybook/addon-docs': 6.5.16_pjt3hb2y6xt75f6zm5wytgwtvi
       '@storybook/addon-measure': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-outline': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-toolbars': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/addon-viewport': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/addons': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/api': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-common': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
+      '@storybook/core-common': 6.5.16_gpdukexrhjgu66opmh7iixboiu
       '@storybook/node-logger': 6.5.16
       core-js: 3.29.0
       react: 18.2.0
@@ -9212,44 +9036,6 @@ packages:
       webpack: 5.75.0
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
-      - eslint
-      - supports-color
-      - typescript
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: true
-
-  /@storybook/addon-interactions/6.5.16_bspqkkbxkxndypqd5swcfjhx6u:
-    resolution: {integrity: sha512-DdTtyp3DgB/SpbM1GQgMnuSEBCkadxmj1mUcPk+Wp2iY+fDwsuoRDkr1H9Oe7IvlBKe7ciR79LEjoaABXNdw4w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-    dependencies:
-      '@devtools-ds/object-inspector': 1.2.1_zula6vjvt3wdocc4mwcxqa6nzi
-      '@storybook/addons': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/api': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/client-logger': 6.5.16
-      '@storybook/components': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-common': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/core-events': 6.5.16
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/instrumenter': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/theming': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      core-js: 3.29.0
-      global: 4.4.0
-      jest-mock: 27.5.1
-      polished: 4.2.2
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      ts-dedent: 2.2.0
-    transitivePeerDependencies:
-      - '@types/react'
       - eslint
       - supports-color
       - typescript
@@ -9515,144 +9301,6 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/builder-webpack4/6.5.16_3okg5sz67cj64fzm2duc7o3pe4:
-    resolution: {integrity: sha512-YqDIrVNsUo8r9xc6AxsYDLxVYtMgl5Bxk+8/h1adsOko+jAFhdg6hOcAVxEmoSI0TMASOOVMFlT2hr23ppN2rQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.21.0
-      '@storybook/addons': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/api': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/channel-postmessage': 6.5.16
-      '@storybook/channels': 6.5.16
-      '@storybook/client-api': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/client-logger': 6.5.16
-      '@storybook/components': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-common': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/core-events': 6.5.16
-      '@storybook/node-logger': 6.5.16
-      '@storybook/preview-web': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/router': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/semver': 7.3.2
-      '@storybook/store': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/theming': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/ui': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@types/node': 16.18.14
-      '@types/webpack': 4.41.33
-      autoprefixer: 9.8.8
-      babel-loader: 8.3.0_idmflsbzmivcz6fnnmcaipezqe
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      core-js: 3.29.0
-      css-loader: 3.6.0_webpack@4.46.0
-      file-loader: 6.2.0_webpack@4.46.0
-      find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6_dz27hs6bxkpycn63nhufh2na6a
-      glob: 7.2.3
-      glob-promise: 3.4.0_glob@7.2.3
-      global: 4.4.0
-      html-webpack-plugin: 4.5.2_webpack@4.46.0
-      pnp-webpack-plugin: 1.6.4_typescript@5.0.2
-      postcss: 7.0.39
-      postcss-flexbugs-fixes: 4.2.1
-      postcss-loader: 4.3.0_gzaxsinx64nntyd3vmdqwl7coe
-      raw-loader: 4.0.2_webpack@4.46.0
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      stable: 0.1.8
-      style-loader: 1.3.0_webpack@4.46.0
-      terser-webpack-plugin: 4.2.3_webpack@4.46.0
-      ts-dedent: 2.2.0
-      typescript: 5.0.2
-      url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
-      util-deprecate: 1.0.2
-      webpack: 4.46.0
-      webpack-dev-middleware: 3.7.3_webpack@4.46.0
-      webpack-filter-warnings-plugin: 1.2.1_webpack@4.46.0
-      webpack-hot-middleware: 2.25.3
-      webpack-virtual-modules: 0.2.2
-    transitivePeerDependencies:
-      - bluebird
-      - eslint
-      - supports-color
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: true
-
-  /@storybook/builder-webpack4/6.5.16_agorczejfgplf4bmymavqdzafy:
-    resolution: {integrity: sha512-YqDIrVNsUo8r9xc6AxsYDLxVYtMgl5Bxk+8/h1adsOko+jAFhdg6hOcAVxEmoSI0TMASOOVMFlT2hr23ppN2rQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.21.0
-      '@storybook/addons': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/api': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/channel-postmessage': 6.5.16
-      '@storybook/channels': 6.5.16
-      '@storybook/client-api': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/client-logger': 6.5.16
-      '@storybook/components': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/core-common': 6.5.16_agorczejfgplf4bmymavqdzafy
-      '@storybook/core-events': 6.5.16
-      '@storybook/node-logger': 6.5.16
-      '@storybook/preview-web': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/router': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/semver': 7.3.2
-      '@storybook/store': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/theming': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/ui': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@types/node': 16.18.14
-      '@types/webpack': 4.41.33
-      autoprefixer: 9.8.8
-      babel-loader: 8.3.0_idmflsbzmivcz6fnnmcaipezqe
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      core-js: 3.29.0
-      css-loader: 3.6.0_webpack@4.46.0
-      file-loader: 6.2.0_webpack@4.46.0
-      find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6_ikqt5m4x57vlca6bzw57fnhhpq
-      glob: 7.2.3
-      glob-promise: 3.4.0_glob@7.2.3
-      global: 4.4.0
-      html-webpack-plugin: 4.5.2_webpack@4.46.0
-      pnp-webpack-plugin: 1.6.4_typescript@5.0.2
-      postcss: 7.0.39
-      postcss-flexbugs-fixes: 4.2.1
-      postcss-loader: 4.3.0_gzaxsinx64nntyd3vmdqwl7coe
-      raw-loader: 4.0.2_webpack@4.46.0
-      react: 16.14.0
-      react-dom: 16.14.0_react@16.14.0
-      stable: 0.1.8
-      style-loader: 1.3.0_webpack@4.46.0
-      terser-webpack-plugin: 4.2.3_webpack@4.46.0
-      ts-dedent: 2.2.0
-      typescript: 5.0.2
-      url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
-      util-deprecate: 1.0.2
-      webpack: 4.46.0
-      webpack-dev-middleware: 3.7.3_webpack@4.46.0
-      webpack-filter-warnings-plugin: 1.2.1_webpack@4.46.0
-      webpack-hot-middleware: 2.25.3
-      webpack-virtual-modules: 0.2.2
-    transitivePeerDependencies:
-      - bluebird
-      - eslint
-      - supports-color
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: true
-
   /@storybook/builder-webpack4/6.5.16_gpdukexrhjgu66opmh7iixboiu:
     resolution: {integrity: sha512-YqDIrVNsUo8r9xc6AxsYDLxVYtMgl5Bxk+8/h1adsOko+jAFhdg6hOcAVxEmoSI0TMASOOVMFlT2hr23ppN2rQ==}
     peerDependencies:
@@ -9722,8 +9370,8 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/builder-webpack5/6.5.16_3okg5sz67cj64fzm2duc7o3pe4:
-    resolution: {integrity: sha512-kh8Sofm1sbijaHDWtm0sXabqACHVFjikU/fIkkW786kpjoPIPIec1a+hrLgDsZxMU3I7XapSOaCFzWt6FjVXjg==}
+  /@storybook/builder-webpack4/6.5.16_lftz7ile6ycte5eulpmwusmyaa:
+    resolution: {integrity: sha512-YqDIrVNsUo8r9xc6AxsYDLxVYtMgl5Bxk+8/h1adsOko+jAFhdg6hOcAVxEmoSI0TMASOOVMFlT2hr23ppN2rQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
@@ -9733,52 +9381,59 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.21.0
-      '@storybook/addons': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/api': 6.5.16_biqbaboplfbrettd7655fr4n2y
+      '@storybook/addons': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/api': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/channel-postmessage': 6.5.16
       '@storybook/channels': 6.5.16
-      '@storybook/client-api': 6.5.16_biqbaboplfbrettd7655fr4n2y
+      '@storybook/client-api': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/client-logger': 6.5.16
-      '@storybook/components': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-common': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
+      '@storybook/components': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/core-common': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
       '@storybook/core-events': 6.5.16
       '@storybook/node-logger': 6.5.16
-      '@storybook/preview-web': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/router': 6.5.16_biqbaboplfbrettd7655fr4n2y
+      '@storybook/preview-web': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/router': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@storybook/semver': 7.3.2
-      '@storybook/store': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/theming': 6.5.16_biqbaboplfbrettd7655fr4n2y
+      '@storybook/store': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/theming': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/ui': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@types/node': 16.18.14
-      babel-loader: 8.3.0_qoaxtqicpzj5p3ubthw53xafqm
-      babel-plugin-named-exports-order: 0.0.2
-      browser-assert: 1.2.1
+      '@types/webpack': 4.41.33
+      autoprefixer: 9.8.8
+      babel-loader: 8.3.0_idmflsbzmivcz6fnnmcaipezqe
       case-sensitive-paths-webpack-plugin: 2.4.0
       core-js: 3.29.0
-      css-loader: 5.2.7_webpack@5.75.0
-      fork-ts-checker-webpack-plugin: 6.5.3_h5wu2rkrstopp4ioziilohop5e
+      css-loader: 3.6.0_webpack@4.46.0
+      file-loader: 6.2.0_webpack@4.46.0
+      find-up: 5.0.0
+      fork-ts-checker-webpack-plugin: 4.1.6_evijigonbo4skk2vlqtwtdqibu
       glob: 7.2.3
       glob-promise: 3.4.0_glob@7.2.3
-      html-webpack-plugin: 5.5.0_webpack@5.75.0
-      path-browserify: 1.0.1
-      process: 0.11.10
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
+      global: 4.4.0
+      html-webpack-plugin: 4.5.2_webpack@4.46.0
+      pnp-webpack-plugin: 1.6.4_typescript@4.9.5
+      postcss: 7.0.39
+      postcss-flexbugs-fixes: 4.2.1
+      postcss-loader: 4.3.0_gzaxsinx64nntyd3vmdqwl7coe
+      raw-loader: 4.0.2_webpack@4.46.0
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
       stable: 0.1.8
-      style-loader: 2.0.0_webpack@5.75.0
-      terser-webpack-plugin: 5.3.6_webpack@5.75.0
+      style-loader: 1.3.0_webpack@4.46.0
+      terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 5.0.2
+      typescript: 4.9.5
+      url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
-      webpack: 5.75.0
-      webpack-dev-middleware: 4.3.0_webpack@5.75.0
+      webpack: 4.46.0
+      webpack-dev-middleware: 3.7.3_webpack@4.46.0
+      webpack-filter-warnings-plugin: 1.2.1_webpack@4.46.0
       webpack-hot-middleware: 2.25.3
-      webpack-virtual-modules: 0.4.6
+      webpack-virtual-modules: 0.2.2
     transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
+      - bluebird
       - eslint
       - supports-color
-      - uglify-js
       - vue-template-compiler
       - webpack-cli
       - webpack-command
@@ -10016,7 +9671,7 @@ packages:
       webpack: 5.75.0
     dev: true
 
-  /@storybook/core-client/6.5.16_eafqnq2fuwgbhzuhulxq4imeai:
+  /@storybook/core-client/6.5.16_ppj5jgv66slzmjcyvawnxcoui4:
     resolution: {integrity: sha512-14IRaDrVtKrQ+gNWC0wPwkCNfkZOKghYV/swCUnQX3rP99defsZK8Hc7xHIYoAiOP5+sc3sweRAxgmFiJeQ1Ig==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
@@ -10047,50 +9702,13 @@ packages:
       react-dom: 16.14.0_react@16.14.0
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
-      typescript: 5.0.2
+      typescript: 4.9.5
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 5.75.0
     dev: true
 
-  /@storybook/core-client/6.5.16_knoe7ecx55mqoel6hxhczj6jnm:
-    resolution: {integrity: sha512-14IRaDrVtKrQ+gNWC0wPwkCNfkZOKghYV/swCUnQX3rP99defsZK8Hc7xHIYoAiOP5+sc3sweRAxgmFiJeQ1Ig==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      typescript: '*'
-      webpack: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@storybook/addons': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/channel-postmessage': 6.5.16
-      '@storybook/channel-websocket': 6.5.16
-      '@storybook/client-api': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/client-logger': 6.5.16
-      '@storybook/core-events': 6.5.16
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/preview-web': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/store': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/ui': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      airbnb-js-shims: 2.2.1
-      ansi-to-html: 0.6.15
-      core-js: 3.29.0
-      global: 4.4.0
-      lodash: 4.17.21
-      qs: 6.11.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      regenerator-runtime: 0.13.11
-      ts-dedent: 2.2.0
-      typescript: 5.0.2
-      unfetch: 4.2.0
-      util-deprecate: 1.0.2
-      webpack: 5.75.0
-    dev: true
-
-  /@storybook/core-client/6.5.16_vdrk2yduaqxzwg2rficdt2b4g4:
+  /@storybook/core-client/6.5.16_prilnw27wu4nsindseyg35liui:
     resolution: {integrity: sha512-14IRaDrVtKrQ+gNWC0wPwkCNfkZOKghYV/swCUnQX3rP99defsZK8Hc7xHIYoAiOP5+sc3sweRAxgmFiJeQ1Ig==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
@@ -10121,44 +9739,7 @@ packages:
       react-dom: 16.14.0_react@16.14.0
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
-      typescript: 5.0.2
-      unfetch: 4.2.0
-      util-deprecate: 1.0.2
-      webpack: 4.46.0
-    dev: true
-
-  /@storybook/core-client/6.5.16_ya45otn6rkalgmmwrtbmo45g7i:
-    resolution: {integrity: sha512-14IRaDrVtKrQ+gNWC0wPwkCNfkZOKghYV/swCUnQX3rP99defsZK8Hc7xHIYoAiOP5+sc3sweRAxgmFiJeQ1Ig==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      typescript: '*'
-      webpack: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@storybook/addons': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/channel-postmessage': 6.5.16
-      '@storybook/channel-websocket': 6.5.16
-      '@storybook/client-api': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/client-logger': 6.5.16
-      '@storybook/core-events': 6.5.16
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/preview-web': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/store': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/ui': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      airbnb-js-shims: 2.2.1
-      ansi-to-html: 0.6.15
-      core-js: 3.29.0
-      global: 4.4.0
-      lodash: 4.17.21
-      qs: 6.11.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      regenerator-runtime: 0.13.11
-      ts-dedent: 2.2.0
-      typescript: 5.0.2
+      typescript: 4.9.5
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -10199,148 +9780,6 @@ packages:
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 4.46.0
-    dev: true
-
-  /@storybook/core-common/6.5.16_3okg5sz67cj64fzm2duc7o3pe4:
-    resolution: {integrity: sha512-2qtnKP3TTOzt2cp6LXKRTh7XrI9z5VanMnMTgeoFcA5ebnndD4V6BExQUdYPClE/QooLx6blUWNgS9dFEpjSqQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.21.0
-      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-proposal-decorators': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-proposal-export-default-from': 7.18.10_@babel+core@7.21.0
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7_@babel+core@7.21.0
-      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.21.0
-      '@babel/plugin-transform-arrow-functions': 7.20.7_@babel+core@7.21.0
-      '@babel/plugin-transform-block-scoping': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-transform-classes': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-transform-destructuring': 7.20.7_@babel+core@7.21.0
-      '@babel/plugin-transform-for-of': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.21.0
-      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-transform-spread': 7.20.7_@babel+core@7.21.0
-      '@babel/preset-env': 7.20.2_@babel+core@7.21.0
-      '@babel/preset-react': 7.18.6_@babel+core@7.21.0
-      '@babel/preset-typescript': 7.21.0_@babel+core@7.21.0
-      '@babel/register': 7.21.0_@babel+core@7.21.0
-      '@storybook/node-logger': 6.5.16
-      '@storybook/semver': 7.3.2
-      '@types/node': 16.18.14
-      '@types/pretty-hrtime': 1.0.1
-      babel-loader: 8.3.0_idmflsbzmivcz6fnnmcaipezqe
-      babel-plugin-macros: 3.1.0
-      babel-plugin-polyfill-corejs3: 0.1.7_@babel+core@7.21.0
-      chalk: 4.1.2
-      core-js: 3.29.0
-      express: 4.18.2
-      file-system-cache: 1.1.0
-      find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3_dz27hs6bxkpycn63nhufh2na6a
-      fs-extra: 9.1.0
-      glob: 7.2.3
-      handlebars: 4.7.7
-      interpret: 2.2.0
-      json5: 2.2.3
-      lazy-universal-dotenv: 3.0.1
-      picomatch: 2.3.1
-      pkg-dir: 5.0.0
-      pretty-hrtime: 1.0.3
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      resolve-from: 5.0.0
-      slash: 3.0.0
-      telejson: 6.0.8
-      ts-dedent: 2.2.0
-      typescript: 5.0.2
-      util-deprecate: 1.0.2
-      webpack: 4.46.0
-    transitivePeerDependencies:
-      - eslint
-      - supports-color
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: true
-
-  /@storybook/core-common/6.5.16_agorczejfgplf4bmymavqdzafy:
-    resolution: {integrity: sha512-2qtnKP3TTOzt2cp6LXKRTh7XrI9z5VanMnMTgeoFcA5ebnndD4V6BExQUdYPClE/QooLx6blUWNgS9dFEpjSqQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.21.0
-      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-proposal-decorators': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-proposal-export-default-from': 7.18.10_@babel+core@7.21.0
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7_@babel+core@7.21.0
-      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.21.0
-      '@babel/plugin-transform-arrow-functions': 7.20.7_@babel+core@7.21.0
-      '@babel/plugin-transform-block-scoping': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-transform-classes': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-transform-destructuring': 7.20.7_@babel+core@7.21.0
-      '@babel/plugin-transform-for-of': 7.21.0_@babel+core@7.21.0
-      '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.21.0
-      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.21.0
-      '@babel/plugin-transform-spread': 7.20.7_@babel+core@7.21.0
-      '@babel/preset-env': 7.20.2_@babel+core@7.21.0
-      '@babel/preset-react': 7.18.6_@babel+core@7.21.0
-      '@babel/preset-typescript': 7.21.0_@babel+core@7.21.0
-      '@babel/register': 7.21.0_@babel+core@7.21.0
-      '@storybook/node-logger': 6.5.16
-      '@storybook/semver': 7.3.2
-      '@types/node': 16.18.14
-      '@types/pretty-hrtime': 1.0.1
-      babel-loader: 8.3.0_idmflsbzmivcz6fnnmcaipezqe
-      babel-plugin-macros: 3.1.0
-      babel-plugin-polyfill-corejs3: 0.1.7_@babel+core@7.21.0
-      chalk: 4.1.2
-      core-js: 3.29.0
-      express: 4.18.2
-      file-system-cache: 1.1.0
-      find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3_ikqt5m4x57vlca6bzw57fnhhpq
-      fs-extra: 9.1.0
-      glob: 7.2.3
-      handlebars: 4.7.7
-      interpret: 2.2.0
-      json5: 2.2.3
-      lazy-universal-dotenv: 3.0.1
-      picomatch: 2.3.1
-      pkg-dir: 5.0.0
-      pretty-hrtime: 1.0.3
-      react: 16.14.0
-      react-dom: 16.14.0_react@16.14.0
-      resolve-from: 5.0.0
-      slash: 3.0.0
-      telejson: 6.0.8
-      ts-dedent: 2.2.0
-      typescript: 5.0.2
-      util-deprecate: 1.0.2
-      webpack: 4.46.0
-    transitivePeerDependencies:
-      - eslint
-      - supports-color
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
     dev: true
 
   /@storybook/core-common/6.5.16_gpdukexrhjgu66opmh7iixboiu:
@@ -10414,243 +9853,81 @@ packages:
       - webpack-command
     dev: true
 
+  /@storybook/core-common/6.5.16_lftz7ile6ycte5eulpmwusmyaa:
+    resolution: {integrity: sha512-2qtnKP3TTOzt2cp6LXKRTh7XrI9z5VanMnMTgeoFcA5ebnndD4V6BExQUdYPClE/QooLx6blUWNgS9dFEpjSqQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/plugin-proposal-class-properties': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-proposal-decorators': 7.21.0_@babel+core@7.21.0
+      '@babel/plugin-proposal-export-default-from': 7.18.10_@babel+core@7.21.0
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-proposal-optional-chaining': 7.21.0_@babel+core@7.21.0
+      '@babel/plugin-proposal-private-methods': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0_@babel+core@7.21.0
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.21.0
+      '@babel/plugin-transform-arrow-functions': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-transform-block-scoping': 7.21.0_@babel+core@7.21.0
+      '@babel/plugin-transform-classes': 7.21.0_@babel+core@7.21.0
+      '@babel/plugin-transform-destructuring': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-transform-for-of': 7.21.0_@babel+core@7.21.0
+      '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.21.0
+      '@babel/plugin-transform-shorthand-properties': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-spread': 7.20.7_@babel+core@7.21.0
+      '@babel/preset-env': 7.20.2_@babel+core@7.21.0
+      '@babel/preset-react': 7.18.6_@babel+core@7.21.0
+      '@babel/preset-typescript': 7.21.0_@babel+core@7.21.0
+      '@babel/register': 7.21.0_@babel+core@7.21.0
+      '@storybook/node-logger': 6.5.16
+      '@storybook/semver': 7.3.2
+      '@types/node': 16.18.14
+      '@types/pretty-hrtime': 1.0.1
+      babel-loader: 8.3.0_idmflsbzmivcz6fnnmcaipezqe
+      babel-plugin-macros: 3.1.0
+      babel-plugin-polyfill-corejs3: 0.1.7_@babel+core@7.21.0
+      chalk: 4.1.2
+      core-js: 3.29.0
+      express: 4.18.2
+      file-system-cache: 1.1.0
+      find-up: 5.0.0
+      fork-ts-checker-webpack-plugin: 6.5.3_evijigonbo4skk2vlqtwtdqibu
+      fs-extra: 9.1.0
+      glob: 7.2.3
+      handlebars: 4.7.7
+      interpret: 2.2.0
+      json5: 2.2.3
+      lazy-universal-dotenv: 3.0.1
+      picomatch: 2.3.1
+      pkg-dir: 5.0.0
+      pretty-hrtime: 1.0.3
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
+      resolve-from: 5.0.0
+      slash: 3.0.0
+      telejson: 6.0.8
+      ts-dedent: 2.2.0
+      typescript: 4.9.5
+      util-deprecate: 1.0.2
+      webpack: 4.46.0
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-command
+    dev: true
+
   /@storybook/core-events/6.5.16:
     resolution: {integrity: sha512-qMZQwmvzpH5F2uwNUllTPg6eZXr2OaYZQRRN8VZJiuorZzDNdAFmiVWMWdkThwmyLEJuQKXxqCL8lMj/7PPM+g==}
     dependencies:
       core-js: 3.29.0
-    dev: true
-
-  /@storybook/core-server/6.5.16_2hjnlaxoylvcgmvfub26vzp7ou:
-    resolution: {integrity: sha512-/3NPfmNyply395Dm0zaVZ8P9aruwO+tPx4D6/jpw8aqrRSwvAMndPMpoMCm0NXcpSm5rdX+Je4S3JW6JcggFkA==}
-    peerDependencies:
-      '@storybook/builder-webpack5': '*'
-      '@storybook/manager-webpack5': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      typescript: '*'
-    peerDependenciesMeta:
-      '@storybook/builder-webpack5':
-        optional: true
-      '@storybook/manager-webpack5':
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/builder-webpack5': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/core-client': 6.5.16_ya45otn6rkalgmmwrtbmo45g7i
-      '@storybook/core-common': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/core-events': 6.5.16
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/csf-tools': 6.5.16
-      '@storybook/manager-webpack4': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/manager-webpack5': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/node-logger': 6.5.16
-      '@storybook/semver': 7.3.2
-      '@storybook/store': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/telemetry': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@types/node': 16.18.14
-      '@types/node-fetch': 2.6.2
-      '@types/pretty-hrtime': 1.0.1
-      '@types/webpack': 4.41.33
-      better-opn: 2.1.1
-      boxen: 5.1.2
-      chalk: 4.1.2
-      cli-table3: 0.6.3
-      commander: 6.2.1
-      compression: 1.7.4
-      core-js: 3.29.0
-      cpy: 8.1.2
-      detect-port: 1.5.1
-      express: 4.18.2
-      fs-extra: 9.1.0
-      global: 4.4.0
-      globby: 11.1.0
-      ip: 2.0.0
-      lodash: 4.17.21
-      node-fetch: 2.6.9
-      open: 8.4.2
-      pretty-hrtime: 1.0.3
-      prompts: 2.4.2
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      regenerator-runtime: 0.13.11
-      serve-favicon: 2.5.0
-      slash: 3.0.0
-      telejson: 6.0.8
-      ts-dedent: 2.2.0
-      typescript: 5.0.2
-      util-deprecate: 1.0.2
-      watchpack: 2.4.0
-      webpack: 4.46.0
-      ws: 8.12.1
-      x-default-browser: 0.4.0
-    transitivePeerDependencies:
-      - '@storybook/mdx2-csf'
-      - bluebird
-      - bufferutil
-      - encoding
-      - eslint
-      - supports-color
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: true
-
-  /@storybook/core-server/6.5.16_3okg5sz67cj64fzm2duc7o3pe4:
-    resolution: {integrity: sha512-/3NPfmNyply395Dm0zaVZ8P9aruwO+tPx4D6/jpw8aqrRSwvAMndPMpoMCm0NXcpSm5rdX+Je4S3JW6JcggFkA==}
-    peerDependencies:
-      '@storybook/builder-webpack5': '*'
-      '@storybook/manager-webpack5': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      typescript: '*'
-    peerDependenciesMeta:
-      '@storybook/builder-webpack5':
-        optional: true
-      '@storybook/manager-webpack5':
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/core-client': 6.5.16_ya45otn6rkalgmmwrtbmo45g7i
-      '@storybook/core-common': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/core-events': 6.5.16
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/csf-tools': 6.5.16
-      '@storybook/manager-webpack4': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/node-logger': 6.5.16
-      '@storybook/semver': 7.3.2
-      '@storybook/store': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/telemetry': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@types/node': 16.18.14
-      '@types/node-fetch': 2.6.2
-      '@types/pretty-hrtime': 1.0.1
-      '@types/webpack': 4.41.33
-      better-opn: 2.1.1
-      boxen: 5.1.2
-      chalk: 4.1.2
-      cli-table3: 0.6.3
-      commander: 6.2.1
-      compression: 1.7.4
-      core-js: 3.29.0
-      cpy: 8.1.2
-      detect-port: 1.5.1
-      express: 4.18.2
-      fs-extra: 9.1.0
-      global: 4.4.0
-      globby: 11.1.0
-      ip: 2.0.0
-      lodash: 4.17.21
-      node-fetch: 2.6.9
-      open: 8.4.2
-      pretty-hrtime: 1.0.3
-      prompts: 2.4.2
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      regenerator-runtime: 0.13.11
-      serve-favicon: 2.5.0
-      slash: 3.0.0
-      telejson: 6.0.8
-      ts-dedent: 2.2.0
-      typescript: 5.0.2
-      util-deprecate: 1.0.2
-      watchpack: 2.4.0
-      webpack: 4.46.0
-      ws: 8.12.1
-      x-default-browser: 0.4.0
-    transitivePeerDependencies:
-      - '@storybook/mdx2-csf'
-      - bluebird
-      - bufferutil
-      - encoding
-      - eslint
-      - supports-color
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: true
-
-  /@storybook/core-server/6.5.16_agorczejfgplf4bmymavqdzafy:
-    resolution: {integrity: sha512-/3NPfmNyply395Dm0zaVZ8P9aruwO+tPx4D6/jpw8aqrRSwvAMndPMpoMCm0NXcpSm5rdX+Je4S3JW6JcggFkA==}
-    peerDependencies:
-      '@storybook/builder-webpack5': '*'
-      '@storybook/manager-webpack5': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      typescript: '*'
-    peerDependenciesMeta:
-      '@storybook/builder-webpack5':
-        optional: true
-      '@storybook/manager-webpack5':
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.5.16_agorczejfgplf4bmymavqdzafy
-      '@storybook/core-client': 6.5.16_vdrk2yduaqxzwg2rficdt2b4g4
-      '@storybook/core-common': 6.5.16_agorczejfgplf4bmymavqdzafy
-      '@storybook/core-events': 6.5.16
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/csf-tools': 6.5.16
-      '@storybook/manager-webpack4': 6.5.16_agorczejfgplf4bmymavqdzafy
-      '@storybook/node-logger': 6.5.16
-      '@storybook/semver': 7.3.2
-      '@storybook/store': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/telemetry': 6.5.16_agorczejfgplf4bmymavqdzafy
-      '@types/node': 16.18.14
-      '@types/node-fetch': 2.6.2
-      '@types/pretty-hrtime': 1.0.1
-      '@types/webpack': 4.41.33
-      better-opn: 2.1.1
-      boxen: 5.1.2
-      chalk: 4.1.2
-      cli-table3: 0.6.3
-      commander: 6.2.1
-      compression: 1.7.4
-      core-js: 3.29.0
-      cpy: 8.1.2
-      detect-port: 1.5.1
-      express: 4.18.2
-      fs-extra: 9.1.0
-      global: 4.4.0
-      globby: 11.1.0
-      ip: 2.0.0
-      lodash: 4.17.21
-      node-fetch: 2.6.9
-      open: 8.4.2
-      pretty-hrtime: 1.0.3
-      prompts: 2.4.2
-      react: 16.14.0
-      react-dom: 16.14.0_react@16.14.0
-      regenerator-runtime: 0.13.11
-      serve-favicon: 2.5.0
-      slash: 3.0.0
-      telejson: 6.0.8
-      ts-dedent: 2.2.0
-      typescript: 5.0.2
-      util-deprecate: 1.0.2
-      watchpack: 2.4.0
-      webpack: 4.46.0
-      ws: 8.12.1
-      x-default-browser: 0.4.0
-    transitivePeerDependencies:
-      - '@storybook/mdx2-csf'
-      - bluebird
-      - bufferutil
-      - encoding
-      - eslint
-      - supports-color
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
     dev: true
 
   /@storybook/core-server/6.5.16_dufhsi5jhqecbkntwsvno3effq:
@@ -10732,6 +10009,160 @@ packages:
       - webpack-command
     dev: true
 
+  /@storybook/core-server/6.5.16_gpdukexrhjgu66opmh7iixboiu:
+    resolution: {integrity: sha512-/3NPfmNyply395Dm0zaVZ8P9aruwO+tPx4D6/jpw8aqrRSwvAMndPMpoMCm0NXcpSm5rdX+Je4S3JW6JcggFkA==}
+    peerDependencies:
+      '@storybook/builder-webpack5': '*'
+      '@storybook/manager-webpack5': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
+      typescript: '*'
+    peerDependenciesMeta:
+      '@storybook/builder-webpack5':
+        optional: true
+      '@storybook/manager-webpack5':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.7
+      '@storybook/builder-webpack4': 6.5.16_gpdukexrhjgu66opmh7iixboiu
+      '@storybook/core-client': 6.5.16_yx6v2mahc4rgaakyal2wzgtgta
+      '@storybook/core-common': 6.5.16_gpdukexrhjgu66opmh7iixboiu
+      '@storybook/core-events': 6.5.16
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/csf-tools': 6.5.16
+      '@storybook/manager-webpack4': 6.5.16_gpdukexrhjgu66opmh7iixboiu
+      '@storybook/node-logger': 6.5.16
+      '@storybook/semver': 7.3.2
+      '@storybook/store': 6.5.16_biqbaboplfbrettd7655fr4n2y
+      '@storybook/telemetry': 6.5.16_gpdukexrhjgu66opmh7iixboiu
+      '@types/node': 16.18.14
+      '@types/node-fetch': 2.6.2
+      '@types/pretty-hrtime': 1.0.1
+      '@types/webpack': 4.41.33
+      better-opn: 2.1.1
+      boxen: 5.1.2
+      chalk: 4.1.2
+      cli-table3: 0.6.3
+      commander: 6.2.1
+      compression: 1.7.4
+      core-js: 3.29.0
+      cpy: 8.1.2
+      detect-port: 1.5.1
+      express: 4.18.2
+      fs-extra: 9.1.0
+      global: 4.4.0
+      globby: 11.1.0
+      ip: 2.0.0
+      lodash: 4.17.21
+      node-fetch: 2.6.9
+      open: 8.4.2
+      pretty-hrtime: 1.0.3
+      prompts: 2.4.2
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      regenerator-runtime: 0.13.11
+      serve-favicon: 2.5.0
+      slash: 3.0.0
+      telejson: 6.0.8
+      ts-dedent: 2.2.0
+      typescript: 4.9.5
+      util-deprecate: 1.0.2
+      watchpack: 2.4.0
+      webpack: 4.46.0
+      ws: 8.12.1
+      x-default-browser: 0.4.0
+    transitivePeerDependencies:
+      - '@storybook/mdx2-csf'
+      - bluebird
+      - bufferutil
+      - encoding
+      - eslint
+      - supports-color
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-command
+    dev: true
+
+  /@storybook/core-server/6.5.16_lftz7ile6ycte5eulpmwusmyaa:
+    resolution: {integrity: sha512-/3NPfmNyply395Dm0zaVZ8P9aruwO+tPx4D6/jpw8aqrRSwvAMndPMpoMCm0NXcpSm5rdX+Je4S3JW6JcggFkA==}
+    peerDependencies:
+      '@storybook/builder-webpack5': '*'
+      '@storybook/manager-webpack5': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
+      typescript: '*'
+    peerDependenciesMeta:
+      '@storybook/builder-webpack5':
+        optional: true
+      '@storybook/manager-webpack5':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.7
+      '@storybook/builder-webpack4': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
+      '@storybook/core-client': 6.5.16_prilnw27wu4nsindseyg35liui
+      '@storybook/core-common': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
+      '@storybook/core-events': 6.5.16
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/csf-tools': 6.5.16
+      '@storybook/manager-webpack4': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
+      '@storybook/node-logger': 6.5.16
+      '@storybook/semver': 7.3.2
+      '@storybook/store': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/telemetry': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
+      '@types/node': 16.18.14
+      '@types/node-fetch': 2.6.2
+      '@types/pretty-hrtime': 1.0.1
+      '@types/webpack': 4.41.33
+      better-opn: 2.1.1
+      boxen: 5.1.2
+      chalk: 4.1.2
+      cli-table3: 0.6.3
+      commander: 6.2.1
+      compression: 1.7.4
+      core-js: 3.29.0
+      cpy: 8.1.2
+      detect-port: 1.5.1
+      express: 4.18.2
+      fs-extra: 9.1.0
+      global: 4.4.0
+      globby: 11.1.0
+      ip: 2.0.0
+      lodash: 4.17.21
+      node-fetch: 2.6.9
+      open: 8.4.2
+      pretty-hrtime: 1.0.3
+      prompts: 2.4.2
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
+      regenerator-runtime: 0.13.11
+      serve-favicon: 2.5.0
+      slash: 3.0.0
+      telejson: 6.0.8
+      ts-dedent: 2.2.0
+      typescript: 4.9.5
+      util-deprecate: 1.0.2
+      watchpack: 2.4.0
+      webpack: 4.46.0
+      ws: 8.12.1
+      x-default-browser: 0.4.0
+    transitivePeerDependencies:
+      - '@storybook/mdx2-csf'
+      - bluebird
+      - bufferutil
+      - encoding
+      - eslint
+      - supports-color
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-command
+    dev: true
+
   /@storybook/core/6.5.16_capp2g22qlmrgzpjza7edweqfq:
     resolution: {integrity: sha512-CEF3QFTsm/VMnMKtRNr4rRdLeIkIG0g1t26WcmxTdSThNPBd8CsWzQJ7Jqu7CKiut+MU4A1LMOwbwCE5F2gmyA==}
     peerDependencies:
@@ -10770,7 +10201,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core/6.5.16_eafqnq2fuwgbhzuhulxq4imeai:
+  /@storybook/core/6.5.16_du4ec4v2bzlwppvbtwwgszihqe:
     resolution: {integrity: sha512-CEF3QFTsm/VMnMKtRNr4rRdLeIkIG0g1t26WcmxTdSThNPBd8CsWzQJ7Jqu7CKiut+MU4A1LMOwbwCE5F2gmyA==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -10787,85 +10218,47 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-client': 6.5.16_eafqnq2fuwgbhzuhulxq4imeai
-      '@storybook/core-server': 6.5.16_agorczejfgplf4bmymavqdzafy
+      '@storybook/core-client': 6.5.16_7cwjmjvoo2q6bjzwgpqtqos7pu
+      '@storybook/core-server': 6.5.16_gpdukexrhjgu66opmh7iixboiu
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      typescript: 4.9.5
+      webpack: 5.75.0
+    transitivePeerDependencies:
+      - '@storybook/mdx2-csf'
+      - bluebird
+      - bufferutil
+      - encoding
+      - eslint
+      - supports-color
+      - utf-8-validate
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-command
+    dev: true
+
+  /@storybook/core/6.5.16_ppj5jgv66slzmjcyvawnxcoui4:
+    resolution: {integrity: sha512-CEF3QFTsm/VMnMKtRNr4rRdLeIkIG0g1t26WcmxTdSThNPBd8CsWzQJ7Jqu7CKiut+MU4A1LMOwbwCE5F2gmyA==}
+    peerDependencies:
+      '@storybook/builder-webpack5': '*'
+      '@storybook/manager-webpack5': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
+      typescript: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      '@storybook/builder-webpack5':
+        optional: true
+      '@storybook/manager-webpack5':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@storybook/core-client': 6.5.16_ppj5jgv66slzmjcyvawnxcoui4
+      '@storybook/core-server': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
       react: 16.14.0
       react-dom: 16.14.0_react@16.14.0
-      typescript: 5.0.2
-      webpack: 5.75.0
-    transitivePeerDependencies:
-      - '@storybook/mdx2-csf'
-      - bluebird
-      - bufferutil
-      - encoding
-      - eslint
-      - supports-color
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: true
-
-  /@storybook/core/6.5.16_j6isgradq64sxhr6g2tc233v3u:
-    resolution: {integrity: sha512-CEF3QFTsm/VMnMKtRNr4rRdLeIkIG0g1t26WcmxTdSThNPBd8CsWzQJ7Jqu7CKiut+MU4A1LMOwbwCE5F2gmyA==}
-    peerDependencies:
-      '@storybook/builder-webpack5': '*'
-      '@storybook/manager-webpack5': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      typescript: '*'
-      webpack: '*'
-    peerDependenciesMeta:
-      '@storybook/builder-webpack5':
-        optional: true
-      '@storybook/manager-webpack5':
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@storybook/builder-webpack5': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/core-client': 6.5.16_knoe7ecx55mqoel6hxhczj6jnm
-      '@storybook/core-server': 6.5.16_2hjnlaxoylvcgmvfub26vzp7ou
-      '@storybook/manager-webpack5': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      typescript: 5.0.2
-      webpack: 5.75.0
-    transitivePeerDependencies:
-      - '@storybook/mdx2-csf'
-      - bluebird
-      - bufferutil
-      - encoding
-      - eslint
-      - supports-color
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: true
-
-  /@storybook/core/6.5.16_qloydye4ewsyjp6k6fpsowbfwy:
-    resolution: {integrity: sha512-CEF3QFTsm/VMnMKtRNr4rRdLeIkIG0g1t26WcmxTdSThNPBd8CsWzQJ7Jqu7CKiut+MU4A1LMOwbwCE5F2gmyA==}
-    peerDependencies:
-      '@storybook/builder-webpack5': '*'
-      '@storybook/manager-webpack5': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      typescript: '*'
-      webpack: '*'
-    peerDependenciesMeta:
-      '@storybook/builder-webpack5':
-        optional: true
-      '@storybook/manager-webpack5':
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@storybook/core-client': 6.5.16_knoe7ecx55mqoel6hxhczj6jnm
-      '@storybook/core-server': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      typescript: 5.0.2
+      typescript: 4.9.5
       webpack: 5.75.0
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
@@ -10941,122 +10334,6 @@ packages:
       - react-dom
     dev: true
 
-  /@storybook/manager-webpack4/6.5.16_3okg5sz67cj64fzm2duc7o3pe4:
-    resolution: {integrity: sha512-5VJZwmQU6AgdsBPsYdu886UKBHQ9SJEnFMaeUxKEclXk+iRsmbzlL4GHKyVd6oGX/ZaecZtcHPR6xrzmA4Ziew==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.21.0
-      '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.21.0
-      '@babel/preset-react': 7.18.6_@babel+core@7.21.0
-      '@storybook/addons': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-client': 6.5.16_ya45otn6rkalgmmwrtbmo45g7i
-      '@storybook/core-common': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/node-logger': 6.5.16
-      '@storybook/theming': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/ui': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@types/node': 16.18.14
-      '@types/webpack': 4.41.33
-      babel-loader: 8.3.0_idmflsbzmivcz6fnnmcaipezqe
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      chalk: 4.1.2
-      core-js: 3.29.0
-      css-loader: 3.6.0_webpack@4.46.0
-      express: 4.18.2
-      file-loader: 6.2.0_webpack@4.46.0
-      find-up: 5.0.0
-      fs-extra: 9.1.0
-      html-webpack-plugin: 4.5.2_webpack@4.46.0
-      node-fetch: 2.6.9
-      pnp-webpack-plugin: 1.6.4_typescript@5.0.2
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      read-pkg-up: 7.0.1
-      regenerator-runtime: 0.13.11
-      resolve-from: 5.0.0
-      style-loader: 1.3.0_webpack@4.46.0
-      telejson: 6.0.8
-      terser-webpack-plugin: 4.2.3_webpack@4.46.0
-      ts-dedent: 2.2.0
-      typescript: 5.0.2
-      url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
-      util-deprecate: 1.0.2
-      webpack: 4.46.0
-      webpack-dev-middleware: 3.7.3_webpack@4.46.0
-      webpack-virtual-modules: 0.2.2
-    transitivePeerDependencies:
-      - bluebird
-      - encoding
-      - eslint
-      - supports-color
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: true
-
-  /@storybook/manager-webpack4/6.5.16_agorczejfgplf4bmymavqdzafy:
-    resolution: {integrity: sha512-5VJZwmQU6AgdsBPsYdu886UKBHQ9SJEnFMaeUxKEclXk+iRsmbzlL4GHKyVd6oGX/ZaecZtcHPR6xrzmA4Ziew==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.21.0
-      '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.21.0
-      '@babel/preset-react': 7.18.6_@babel+core@7.21.0
-      '@storybook/addons': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/core-client': 6.5.16_vdrk2yduaqxzwg2rficdt2b4g4
-      '@storybook/core-common': 6.5.16_agorczejfgplf4bmymavqdzafy
-      '@storybook/node-logger': 6.5.16
-      '@storybook/theming': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/ui': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@types/node': 16.18.14
-      '@types/webpack': 4.41.33
-      babel-loader: 8.3.0_idmflsbzmivcz6fnnmcaipezqe
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      chalk: 4.1.2
-      core-js: 3.29.0
-      css-loader: 3.6.0_webpack@4.46.0
-      express: 4.18.2
-      file-loader: 6.2.0_webpack@4.46.0
-      find-up: 5.0.0
-      fs-extra: 9.1.0
-      html-webpack-plugin: 4.5.2_webpack@4.46.0
-      node-fetch: 2.6.9
-      pnp-webpack-plugin: 1.6.4_typescript@5.0.2
-      react: 16.14.0
-      react-dom: 16.14.0_react@16.14.0
-      read-pkg-up: 7.0.1
-      regenerator-runtime: 0.13.11
-      resolve-from: 5.0.0
-      style-loader: 1.3.0_webpack@4.46.0
-      telejson: 6.0.8
-      terser-webpack-plugin: 4.2.3_webpack@4.46.0
-      ts-dedent: 2.2.0
-      typescript: 5.0.2
-      url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
-      util-deprecate: 1.0.2
-      webpack: 4.46.0
-      webpack-dev-middleware: 3.7.3_webpack@4.46.0
-      webpack-virtual-modules: 0.2.2
-    transitivePeerDependencies:
-      - bluebird
-      - encoding
-      - eslint
-      - supports-color
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: true
-
   /@storybook/manager-webpack4/6.5.16_gpdukexrhjgu66opmh7iixboiu:
     resolution: {integrity: sha512-5VJZwmQU6AgdsBPsYdu886UKBHQ9SJEnFMaeUxKEclXk+iRsmbzlL4GHKyVd6oGX/ZaecZtcHPR6xrzmA4Ziew==}
     peerDependencies:
@@ -11115,8 +10392,8 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/manager-webpack5/6.5.16_3okg5sz67cj64fzm2duc7o3pe4:
-    resolution: {integrity: sha512-OtxXv8JCe0r/0rE5HxaFicsNsXA+fqZxzokxquFFgrYf/1Jg4d7QX6/pG5wINF+5qInJfVkRG6xhPzv1s5bk9Q==}
+  /@storybook/manager-webpack4/6.5.16_lftz7ile6ycte5eulpmwusmyaa:
+    resolution: {integrity: sha512-5VJZwmQU6AgdsBPsYdu886UKBHQ9SJEnFMaeUxKEclXk+iRsmbzlL4GHKyVd6oGX/ZaecZtcHPR6xrzmA4Ziew==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
@@ -11128,45 +10405,46 @@ packages:
       '@babel/core': 7.21.0
       '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.21.0
       '@babel/preset-react': 7.18.6_@babel+core@7.21.0
-      '@storybook/addons': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-client': 6.5.16_knoe7ecx55mqoel6hxhczj6jnm
-      '@storybook/core-common': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
+      '@storybook/addons': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/core-client': 6.5.16_prilnw27wu4nsindseyg35liui
+      '@storybook/core-common': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
       '@storybook/node-logger': 6.5.16
-      '@storybook/theming': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/ui': 6.5.16_biqbaboplfbrettd7655fr4n2y
+      '@storybook/theming': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
+      '@storybook/ui': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@types/node': 16.18.14
-      babel-loader: 8.3.0_qoaxtqicpzj5p3ubthw53xafqm
+      '@types/webpack': 4.41.33
+      babel-loader: 8.3.0_idmflsbzmivcz6fnnmcaipezqe
       case-sensitive-paths-webpack-plugin: 2.4.0
       chalk: 4.1.2
       core-js: 3.29.0
-      css-loader: 5.2.7_webpack@5.75.0
+      css-loader: 3.6.0_webpack@4.46.0
       express: 4.18.2
+      file-loader: 6.2.0_webpack@4.46.0
       find-up: 5.0.0
       fs-extra: 9.1.0
-      html-webpack-plugin: 5.5.0_webpack@5.75.0
+      html-webpack-plugin: 4.5.2_webpack@4.46.0
       node-fetch: 2.6.9
-      process: 0.11.10
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
+      pnp-webpack-plugin: 1.6.4_typescript@4.9.5
+      react: 16.14.0
+      react-dom: 16.14.0_react@16.14.0
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.11
       resolve-from: 5.0.0
-      style-loader: 2.0.0_webpack@5.75.0
+      style-loader: 1.3.0_webpack@4.46.0
       telejson: 6.0.8
-      terser-webpack-plugin: 5.3.6_webpack@5.75.0
+      terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 5.0.2
+      typescript: 4.9.5
+      url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
-      webpack: 5.75.0
-      webpack-dev-middleware: 4.3.0_webpack@5.75.0
-      webpack-virtual-modules: 0.4.6
+      webpack: 4.46.0
+      webpack-dev-middleware: 3.7.3_webpack@4.46.0
+      webpack-virtual-modules: 0.2.2
     transitivePeerDependencies:
-      - '@swc/core'
+      - bluebird
       - encoding
-      - esbuild
       - eslint
       - supports-color
-      - uglify-js
       - vue-template-compiler
       - webpack-cli
       - webpack-command
@@ -11264,7 +10542,7 @@ packages:
       core-js: 3.29.0
     dev: true
 
-  /@storybook/preact/6.5.16_ymutfbf23ptyofokmjee4ypvem:
+  /@storybook/preact/6.5.16_4pbvjs5xcqoa4t5hqii55vh5ei:
     resolution: {integrity: sha512-Wc9Z1Fz49QKsjYt0ARIcEEhy7HpUl6nrVx52MH+l12x7TD6YqVJv1cC83a7DYtG8E3Xv8CFsXRJEiraDnLFdag==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -11275,8 +10553,8 @@ packages:
       '@babel/core': 7.21.0
       '@babel/plugin-transform-react-jsx': 7.21.0_@babel+core@7.21.0
       '@storybook/addons': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
-      '@storybook/core': 6.5.16_eafqnq2fuwgbhzuhulxq4imeai
-      '@storybook/core-common': 6.5.16_agorczejfgplf4bmymavqdzafy
+      '@storybook/core': 6.5.16_ppj5jgv66slzmjcyvawnxcoui4
+      '@storybook/core-common': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/store': 6.5.16_wcqkhtmu7mswc6yz4uyexck3ty
       '@types/node': 16.18.14
@@ -11309,37 +10587,6 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/preset-create-react-app/4.1.2_b6hd63vudugzmab4punuebqooe:
-    resolution: {integrity: sha512-5uBZPhuyXx4APgLZnhiZ/PqYYprBua5CabQCfAlk+/9V4vSpX+ww+XP4Rl8Ifc/nf/HktgwtJFH4HXrZGRKC4w==}
-    peerDependencies:
-      '@babel/core': '*'
-      '@storybook/node-logger': '*'
-      '@storybook/react': '>=5.2'
-      react-scripts: '>=5.0.0'
-    dependencies:
-      '@babel/core': 7.21.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10_xsftmjzvfioxqs4ify53ibh7ay
-      '@storybook/node-logger': 6.5.16
-      '@storybook/react': 6.5.16_oo3vr6vtphws3bgkmzazea5rvu
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.cd77847.0_uwemawexpmcwp4gcune73namy4
-      '@types/babel__core': 7.20.0
-      babel-plugin-react-docgen: 4.2.1
-      pnp-webpack-plugin: 1.7.0_typescript@5.0.2
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
-      semver: 7.3.8
-    transitivePeerDependencies:
-      - '@types/webpack'
-      - react-refresh
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - typescript
-      - webpack
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-    dev: true
-
   /@storybook/preset-create-react-app/4.1.2_jrqet27rlm2lmiqxjnwoky54w4:
     resolution: {integrity: sha512-5uBZPhuyXx4APgLZnhiZ/PqYYprBua5CabQCfAlk+/9V4vSpX+ww+XP4Rl8Ifc/nf/HktgwtJFH4HXrZGRKC4w==}
     peerDependencies:
@@ -11351,7 +10598,7 @@ packages:
       '@babel/core': 7.21.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.10_xsftmjzvfioxqs4ify53ibh7ay
       '@storybook/node-logger': 6.5.16
-      '@storybook/react': 6.5.16_4obprv6wy6yhlizylxwk4rs74a
+      '@storybook/react': 6.5.16_atbdn65bs3jled2mkfe5k6i2ka
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.cd77847.0_hhrrucqyg4eysmfpujvov2ym5u
       '@types/babel__core': 7.20.0
       babel-plugin-react-docgen: 4.2.1
@@ -11442,25 +10689,6 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_uwemawexpmcwp4gcune73namy4:
-    resolution: {integrity: sha512-eVg3BxlOm2P+chijHBTByr90IZVUtgRW56qEOLX7xlww2NBuKrcavBlcmn+HH7GIUktquWkMPtvy6e0W0NgA5w==}
-    peerDependencies:
-      typescript: '>= 3.x'
-      webpack: '>= 4'
-    dependencies:
-      debug: 4.3.4
-      endent: 2.1.0
-      find-cache-dir: 3.3.2
-      flat-cache: 3.0.4
-      micromatch: 4.0.5
-      react-docgen-typescript: 2.2.2_typescript@5.0.2
-      tslib: 2.5.0
-      typescript: 5.0.2
-      webpack: 5.75.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@storybook/react-docgen-typescript-plugin/1.0.6--canary.9.cd77847.0_hhrrucqyg4eysmfpujvov2ym5u:
     resolution: {integrity: sha512-I4oBYmnUCX5IsrZhg+ST72dubSIV4wdwY+SfqJiJ3NHvDpdb240ZjdHAmjIy/yJh5rh42Fl4jbG8Tr4SzwV53Q==}
     peerDependencies:
@@ -11475,25 +10703,6 @@ packages:
       react-docgen-typescript: 2.2.2_typescript@4.9.5
       tslib: 2.5.0
       typescript: 4.9.5
-      webpack: 5.75.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@storybook/react-docgen-typescript-plugin/1.0.6--canary.9.cd77847.0_uwemawexpmcwp4gcune73namy4:
-    resolution: {integrity: sha512-I4oBYmnUCX5IsrZhg+ST72dubSIV4wdwY+SfqJiJ3NHvDpdb240ZjdHAmjIy/yJh5rh42Fl4jbG8Tr4SzwV53Q==}
-    peerDependencies:
-      typescript: '>= 4.x'
-      webpack: '>= 4'
-    dependencies:
-      debug: 4.3.4
-      endent: 2.1.0
-      find-cache-dir: 3.3.2
-      flat-cache: 3.0.4
-      micromatch: 4.0.5
-      react-docgen-typescript: 2.2.2_typescript@5.0.2
-      tslib: 2.5.0
-      typescript: 5.0.2
       webpack: 5.75.0
     transitivePeerDependencies:
       - supports-color
@@ -11591,99 +10800,7 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@storybook/react/6.5.16_7uctrkj2ghraftlvfygs5kxbxi:
-    resolution: {integrity: sha512-cBtNlOzf/MySpNLBK22lJ8wFU22HnfTB2xJyBk7W7Zi71Lm7Uxkhv1Pz8HdiQndJ0SlsAAQOWjQYsSZsGkZIaA==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': ^7.11.5
-      '@storybook/builder-webpack4': '*'
-      '@storybook/builder-webpack5': '*'
-      '@storybook/manager-webpack4': '*'
-      '@storybook/manager-webpack5': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^18
-      require-from-string: ^2.0.2
-      typescript: '*'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@storybook/builder-webpack4':
-        optional: true
-      '@storybook/builder-webpack5':
-        optional: true
-      '@storybook/manager-webpack4':
-        optional: true
-      '@storybook/manager-webpack5':
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.21.0
-      '@babel/preset-flow': 7.18.6_@babel+core@7.21.0
-      '@babel/preset-react': 7.18.6_@babel+core@7.21.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10_ohj47mxwagpoxvu7nhhwxzphqm
-      '@storybook/addons': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/builder-webpack5': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/client-logger': 6.5.16
-      '@storybook/core': 6.5.16_j6isgradq64sxhr6g2tc233v3u
-      '@storybook/core-common': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/docs-tools': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@storybook/manager-webpack5': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      '@storybook/node-logger': 6.5.16
-      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_uwemawexpmcwp4gcune73namy4
-      '@storybook/semver': 7.3.2
-      '@storybook/store': 6.5.16_biqbaboplfbrettd7655fr4n2y
-      '@types/estree': 0.0.51
-      '@types/node': 16.18.14
-      '@types/webpack-env': 1.18.0
-      acorn: 7.4.1
-      acorn-jsx: 5.3.2_acorn@7.4.1
-      acorn-walk: 7.2.0
-      babel-plugin-add-react-displayname: 0.0.5
-      babel-plugin-react-docgen: 4.2.1
-      core-js: 3.29.0
-      escodegen: 2.0.0
-      fs-extra: 9.1.0
-      global: 4.4.0
-      html-tags: 3.2.0
-      lodash: 4.17.21
-      prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      react-element-to-jsx-string: 14.3.4_biqbaboplfbrettd7655fr4n2y
-      react-refresh: 0.11.0
-      read-pkg-up: 7.0.1
-      regenerator-runtime: 0.13.11
-      require-from-string: 2.0.2
-      ts-dedent: 2.2.0
-      typescript: 5.0.2
-      util-deprecate: 1.0.2
-      webpack: 5.75.0
-    transitivePeerDependencies:
-      - '@storybook/mdx2-csf'
-      - '@swc/core'
-      - '@types/webpack'
-      - bluebird
-      - bufferutil
-      - encoding
-      - esbuild
-      - eslint
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-    dev: true
-
-  /@storybook/react/6.5.16_oo3vr6vtphws3bgkmzazea5rvu:
+  /@storybook/react/6.5.16_atbdn65bs3jled2mkfe5k6i2ka:
     resolution: {integrity: sha512-cBtNlOzf/MySpNLBK22lJ8wFU22HnfTB2xJyBk7W7Zi71Lm7Uxkhv1Pz8HdiQndJ0SlsAAQOWjQYsSZsGkZIaA==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -11717,12 +10834,12 @@ packages:
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.10_ohj47mxwagpoxvu7nhhwxzphqm
       '@storybook/addons': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/client-logger': 6.5.16
-      '@storybook/core': 6.5.16_qloydye4ewsyjp6k6fpsowbfwy
-      '@storybook/core-common': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
+      '@storybook/core': 6.5.16_du4ec4v2bzlwppvbtwwgszihqe
+      '@storybook/core-common': 6.5.16_gpdukexrhjgu66opmh7iixboiu
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@storybook/node-logger': 6.5.16
-      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_uwemawexpmcwp4gcune73namy4
+      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_hhrrucqyg4eysmfpujvov2ym5u
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.16_biqbaboplfbrettd7655fr4n2y
       '@types/estree': 0.0.51
@@ -11748,7 +10865,7 @@ packages:
       regenerator-runtime: 0.13.11
       require-from-string: 2.0.2
       ts-dedent: 2.2.0
-      typescript: 5.0.2
+      typescript: 4.9.5
       util-deprecate: 1.0.2
       webpack: 5.75.0
     transitivePeerDependencies:
@@ -11882,65 +10999,38 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/telemetry/6.5.16_3okg5sz67cj64fzm2duc7o3pe4:
-    resolution: {integrity: sha512-CWr5Uko1l9jJW88yTXsZTj/3GTabPvw0o7pDPOXPp8JRZiJTxv1JFaFCafhK9UzYbgcRuGfCC8kEWPZims7iKA==}
-    dependencies:
-      '@storybook/client-logger': 6.5.16
-      '@storybook/core-common': 6.5.16_3okg5sz67cj64fzm2duc7o3pe4
-      chalk: 4.1.2
-      core-js: 3.29.0
-      detect-package-manager: 2.0.1
-      fetch-retry: 5.0.4
-      fs-extra: 9.1.0
-      global: 4.4.0
-      isomorphic-unfetch: 3.1.0
-      nanoid: 3.3.4
-      read-pkg-up: 7.0.1
-      regenerator-runtime: 0.13.11
-    transitivePeerDependencies:
-      - encoding
-      - eslint
-      - react
-      - react-dom
-      - supports-color
-      - typescript
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: true
-
-  /@storybook/telemetry/6.5.16_agorczejfgplf4bmymavqdzafy:
-    resolution: {integrity: sha512-CWr5Uko1l9jJW88yTXsZTj/3GTabPvw0o7pDPOXPp8JRZiJTxv1JFaFCafhK9UzYbgcRuGfCC8kEWPZims7iKA==}
-    dependencies:
-      '@storybook/client-logger': 6.5.16
-      '@storybook/core-common': 6.5.16_agorczejfgplf4bmymavqdzafy
-      chalk: 4.1.2
-      core-js: 3.29.0
-      detect-package-manager: 2.0.1
-      fetch-retry: 5.0.4
-      fs-extra: 9.1.0
-      global: 4.4.0
-      isomorphic-unfetch: 3.1.0
-      nanoid: 3.3.4
-      read-pkg-up: 7.0.1
-      regenerator-runtime: 0.13.11
-    transitivePeerDependencies:
-      - encoding
-      - eslint
-      - react
-      - react-dom
-      - supports-color
-      - typescript
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-command
-    dev: true
-
   /@storybook/telemetry/6.5.16_gpdukexrhjgu66opmh7iixboiu:
     resolution: {integrity: sha512-CWr5Uko1l9jJW88yTXsZTj/3GTabPvw0o7pDPOXPp8JRZiJTxv1JFaFCafhK9UzYbgcRuGfCC8kEWPZims7iKA==}
     dependencies:
       '@storybook/client-logger': 6.5.16
       '@storybook/core-common': 6.5.16_gpdukexrhjgu66opmh7iixboiu
+      chalk: 4.1.2
+      core-js: 3.29.0
+      detect-package-manager: 2.0.1
+      fetch-retry: 5.0.4
+      fs-extra: 9.1.0
+      global: 4.4.0
+      isomorphic-unfetch: 3.1.0
+      nanoid: 3.3.4
+      read-pkg-up: 7.0.1
+      regenerator-runtime: 0.13.11
+    transitivePeerDependencies:
+      - encoding
+      - eslint
+      - react
+      - react-dom
+      - supports-color
+      - typescript
+      - vue-template-compiler
+      - webpack-cli
+      - webpack-command
+    dev: true
+
+  /@storybook/telemetry/6.5.16_lftz7ile6ycte5eulpmwusmyaa:
+    resolution: {integrity: sha512-CWr5Uko1l9jJW88yTXsZTj/3GTabPvw0o7pDPOXPp8JRZiJTxv1JFaFCafhK9UzYbgcRuGfCC8kEWPZims7iKA==}
+    dependencies:
+      '@storybook/client-logger': 6.5.16
+      '@storybook/core-common': 6.5.16_lftz7ile6ycte5eulpmwusmyaa
       chalk: 4.1.2
       core-js: 3.29.0
       detect-package-manager: 2.0.1
@@ -13206,45 +12296,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/eslint-plugin/5.55.0_qsnvknysi52qtaxqdyqyohkcku:
-    resolution: {integrity: sha512-IZGc50rtbjk+xp5YQoJvmMPmJEYoC53SiKPXyqWfv15XoD2Y5Kju6zN0DwlmaGJp1Iw33JsWJcQ7nw0lGCGjVg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@eslint-community/regexpp': 4.4.0
-      '@typescript-eslint/parser': 5.55.0_j4766f7ecgqbon3u7zlxn5zszu
-      '@typescript-eslint/scope-manager': 5.55.0
-      '@typescript-eslint/type-utils': 5.55.0_j4766f7ecgqbon3u7zlxn5zszu
-      '@typescript-eslint/utils': 5.55.0_j4766f7ecgqbon3u7zlxn5zszu
-      debug: 4.3.4
-      eslint: 8.36.0
-      grapheme-splitter: 1.0.4
-      ignore: 5.2.4
-      natural-compare-lite: 1.4.0
-      semver: 7.3.8
-      tsutils: 3.21.0_typescript@5.0.2
-      typescript: 5.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  /@typescript-eslint/experimental-utils/5.54.1_j4766f7ecgqbon3u7zlxn5zszu:
-    resolution: {integrity: sha512-oqSc2Gr4TL/2M0XRJ9abA1o3Wf1cFJTNqWq0kjdStIIvgMQGZ3TSaFFJ2Cvy3Fgqi9UfDZ8u5idbACssIIyHaw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@typescript-eslint/utils': 5.54.1_j4766f7ecgqbon3u7zlxn5zszu
-      eslint: 8.36.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   /@typescript-eslint/experimental-utils/5.54.1_vgl77cfdswitgr47lm5swmv43m:
     resolution: {integrity: sha512-oqSc2Gr4TL/2M0XRJ9abA1o3Wf1cFJTNqWq0kjdStIIvgMQGZ3TSaFFJ2Cvy3Fgqi9UfDZ8u5idbACssIIyHaw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -13256,25 +12307,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  /@typescript-eslint/parser/5.55.0_j4766f7ecgqbon3u7zlxn5zszu:
-    resolution: {integrity: sha512-ppvmeF7hvdhUUZWSd2EEWfzcFkjJzgNQzVST22nzg958CR+sphy8A6K7LXQZd6V75m1VKjp+J4g/PCEfSCmzhw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.55.0
-      '@typescript-eslint/types': 5.55.0
-      '@typescript-eslint/typescript-estree': 5.55.0_typescript@5.0.2
-      debug: 4.3.4
-      eslint: 8.36.0
-      typescript: 5.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   /@typescript-eslint/parser/5.55.0_vgl77cfdswitgr47lm5swmv43m:
     resolution: {integrity: sha512-ppvmeF7hvdhUUZWSd2EEWfzcFkjJzgNQzVST22nzg958CR+sphy8A6K7LXQZd6V75m1VKjp+J4g/PCEfSCmzhw==}
@@ -13308,25 +12340,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.55.0
       '@typescript-eslint/visitor-keys': 5.55.0
-
-  /@typescript-eslint/type-utils/5.55.0_j4766f7ecgqbon3u7zlxn5zszu:
-    resolution: {integrity: sha512-ObqxBgHIXj8rBNm0yh8oORFrICcJuZPZTqtAFh0oZQyr5DnAHZWfyw54RwpEEH+fD8suZaI0YxvWu5tYE/WswA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.55.0_typescript@5.0.2
-      '@typescript-eslint/utils': 5.55.0_j4766f7ecgqbon3u7zlxn5zszu
-      debug: 4.3.4
-      eslint: 8.36.0
-      tsutils: 3.21.0_typescript@5.0.2
-      typescript: 5.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   /@typescript-eslint/type-utils/5.55.0_vgl77cfdswitgr47lm5swmv43m:
     resolution: {integrity: sha512-ObqxBgHIXj8rBNm0yh8oORFrICcJuZPZTqtAFh0oZQyr5DnAHZWfyw54RwpEEH+fD8suZaI0YxvWu5tYE/WswA==}
@@ -13375,26 +12388,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree/5.54.1_typescript@5.0.2:
-    resolution: {integrity: sha512-bjK5t+S6ffHnVwA0qRPTZrxKSaFYocwFIkZx5k7pvWfsB1I57pO/0M0Skatzzw1sCkjJ83AfGTL0oFIFiDX3bg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.54.1
-      '@typescript-eslint/visitor-keys': 5.54.1
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.3.8
-      tsutils: 3.21.0_typescript@5.0.2
-      typescript: 5.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   /@typescript-eslint/typescript-estree/5.55.0_typescript@4.9.5:
     resolution: {integrity: sha512-I7X4A9ovA8gdpWMpr7b1BN9eEbvlEtWhQvpxp/yogt48fy9Lj3iE3ild/1H3jKBBIYj5YYJmS2+9ystVhC7eaQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -13415,45 +12408,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree/5.55.0_typescript@5.0.2:
-    resolution: {integrity: sha512-I7X4A9ovA8gdpWMpr7b1BN9eEbvlEtWhQvpxp/yogt48fy9Lj3iE3ild/1H3jKBBIYj5YYJmS2+9ystVhC7eaQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.55.0
-      '@typescript-eslint/visitor-keys': 5.55.0
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.3.8
-      tsutils: 3.21.0_typescript@5.0.2
-      typescript: 5.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  /@typescript-eslint/utils/5.54.1_j4766f7ecgqbon3u7zlxn5zszu:
-    resolution: {integrity: sha512-IY5dyQM8XD1zfDe5X8jegX6r2EVU5o/WJnLu/znLPWCBF7KNGC+adacXnt5jEYS9JixDcoccI6CvE4RCjHMzCQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@types/json-schema': 7.0.11
-      '@types/semver': 7.3.13
-      '@typescript-eslint/scope-manager': 5.54.1
-      '@typescript-eslint/types': 5.54.1
-      '@typescript-eslint/typescript-estree': 5.54.1_typescript@5.0.2
-      eslint: 8.36.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.36.0
-      semver: 7.3.8
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   /@typescript-eslint/utils/5.54.1_vgl77cfdswitgr47lm5swmv43m:
     resolution: {integrity: sha512-IY5dyQM8XD1zfDe5X8jegX6r2EVU5o/WJnLu/znLPWCBF7KNGC+adacXnt5jEYS9JixDcoccI6CvE4RCjHMzCQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -13468,25 +12422,6 @@ packages:
       eslint: 8.36.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.36.0
-      semver: 7.3.8
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  /@typescript-eslint/utils/5.55.0_j4766f7ecgqbon3u7zlxn5zszu:
-    resolution: {integrity: sha512-FkW+i2pQKcpDC3AY6DU54yl8Lfl14FVGYDgBTyGKB75cCwV3KpkpTMFi9d9j2WAJ4271LR2HeC5SEWF/CZmmfw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@eslint-community/eslint-utils': 4.2.0_eslint@8.36.0
-      '@types/json-schema': 7.0.11
-      '@types/semver': 7.3.13
-      '@typescript-eslint/scope-manager': 5.55.0
-      '@typescript-eslint/types': 5.55.0
-      '@typescript-eslint/typescript-estree': 5.55.0_typescript@5.0.2
-      eslint: 8.36.0
-      eslint-scope: 5.1.1
       semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
@@ -17845,7 +16780,7 @@ packages:
   /core-util-is/1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
-  /cosmiconfig-typescript-loader/1.0.9_3ge77i23l64vl4dlqvwynlpyne:
+  /cosmiconfig-typescript-loader/1.0.9_epm2eosjl5rrlyrsakgmxyecne:
     resolution: {integrity: sha512-tRuMRhxN4m1Y8hP9SNYfz7jRwt8lZdWxdjg/ohg5esKmsndJIn4yT96oJVcf5x0eA11taXl+sIp+ielu529k6g==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -17855,8 +16790,8 @@ packages:
     dependencies:
       '@types/node': 18.14.6
       cosmiconfig: 7.1.0
-      ts-node: 10.9.1_h3fbjg56t7r6gafnoy6qf2o25e
-      typescript: 5.0.2
+      ts-node: 10.9.1_alpjt73dvgv6kni625hu7f2l4m
+      typescript: 4.9.5
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -20076,40 +19011,6 @@ packages:
       - jest
       - supports-color
 
-  /eslint-config-react-app/7.0.1_wqyc3vbambvdslb2tq3iw5m6b4:
-    resolution: {integrity: sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      eslint: ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.21.0
-      '@babel/eslint-parser': 7.19.1_vtnbfkwqsm6iol5jb3gfhr3fli
-      '@rushstack/eslint-patch': 1.2.0
-      '@typescript-eslint/eslint-plugin': 5.55.0_qsnvknysi52qtaxqdyqyohkcku
-      '@typescript-eslint/parser': 5.55.0_j4766f7ecgqbon3u7zlxn5zszu
-      babel-preset-react-app: 10.0.1
-      confusing-browser-globals: 1.0.11
-      eslint: 8.36.0
-      eslint-plugin-flowtype: 8.0.3_it35xx4fcmk65kxyg5ckcaulci
-      eslint-plugin-import: 2.27.5_a7er6olmtneep4uytpot6gt7wu
-      eslint-plugin-jest: 25.7.0_2llkuoegdowf7lizwo3opddmoq
-      eslint-plugin-jsx-a11y: 6.7.1_eslint@8.36.0
-      eslint-plugin-react: 7.32.2_eslint@8.36.0
-      eslint-plugin-react-hooks: 4.6.0_eslint@8.36.0
-      eslint-plugin-testing-library: 5.10.2_j4766f7ecgqbon3u7zlxn5zszu
-      typescript: 5.0.2
-    transitivePeerDependencies:
-      - '@babel/plugin-syntax-flow'
-      - '@babel/plugin-transform-react-jsx'
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - jest
-      - supports-color
-
   /eslint-import-resolver-node/0.3.7:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
     dependencies:
@@ -20140,7 +19041,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.55.0_j4766f7ecgqbon3u7zlxn5zszu
+      '@typescript-eslint/parser': 5.55.0_vgl77cfdswitgr47lm5swmv43m
       debug: 3.2.7
       eslint: 8.36.0
       eslint-import-resolver-node: 0.3.7
@@ -20171,7 +19072,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.55.0_j4766f7ecgqbon3u7zlxn5zszu
+      '@typescript-eslint/parser': 5.55.0_vgl77cfdswitgr47lm5swmv43m
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -20192,27 +19093,6 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
-
-  /eslint-plugin-jest/25.7.0_2llkuoegdowf7lizwo3opddmoq:
-    resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^4.0.0 || ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      jest: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/eslint-plugin':
-        optional: true
-      jest:
-        optional: true
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 5.55.0_qsnvknysi52qtaxqdyqyohkcku
-      '@typescript-eslint/experimental-utils': 5.54.1_j4766f7ecgqbon3u7zlxn5zszu
-      eslint: 8.36.0
-      jest: 27.5.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   /eslint-plugin-jest/25.7.0_bmsdxalkwzildnsknq5whljqx4:
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
@@ -20289,18 +19169,6 @@ packages:
       resolve: 2.0.0-next.4
       semver: 6.3.0
       string.prototype.matchall: 4.0.8
-
-  /eslint-plugin-testing-library/5.10.2_j4766f7ecgqbon3u7zlxn5zszu:
-    resolution: {integrity: sha512-f1DmDWcz5SDM+IpCkEX0lbFqrrTs8HRsEElzDEqN/EBI0hpRj8Cns5+IVANXswE8/LeybIJqPAOQIFu2j5Y5sw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
-    peerDependencies:
-      eslint: ^7.5.0 || ^8.0.0
-    dependencies:
-      '@typescript-eslint/utils': 5.55.0_j4766f7ecgqbon3u7zlxn5zszu
-      eslint: 8.36.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   /eslint-plugin-testing-library/5.10.2_vgl77cfdswitgr47lm5swmv43m:
     resolution: {integrity: sha512-f1DmDWcz5SDM+IpCkEX0lbFqrrTs8HRsEElzDEqN/EBI0hpRj8Cns5+IVANXswE8/LeybIJqPAOQIFu2j5Y5sw==}
@@ -21354,35 +20222,7 @@ packages:
       - supports-color
     dev: true
 
-  /fork-ts-checker-webpack-plugin/4.1.6_dz27hs6bxkpycn63nhufh2na6a:
-    resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
-    engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
-    peerDependencies:
-      eslint: '>= 6'
-      typescript: '>= 2.7'
-      vue-template-compiler: '*'
-      webpack: '>= 4'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      vue-template-compiler:
-        optional: true
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      chalk: 2.4.2
-      eslint: 8.36.0
-      micromatch: 3.1.10
-      minimatch: 3.1.2
-      semver: 5.7.1
-      tapable: 1.1.3
-      typescript: 5.0.2
-      webpack: 4.46.0
-      worker-rpc: 0.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /fork-ts-checker-webpack-plugin/4.1.6_ikqt5m4x57vlca6bzw57fnhhpq:
+  /fork-ts-checker-webpack-plugin/4.1.6_evijigonbo4skk2vlqtwtdqibu:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -21402,7 +20242,7 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.1
       tapable: 1.1.3
-      typescript: 5.0.2
+      typescript: 4.9.5
       webpack: 4.46.0
       worker-rpc: 0.1.1
     transitivePeerDependencies:
@@ -21468,70 +20308,7 @@ packages:
       webpack: 4.46.0
     dev: true
 
-  /fork-ts-checker-webpack-plugin/6.5.3_dz27hs6bxkpycn63nhufh2na6a:
-    resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
-    engines: {node: '>=10', yarn: '>=1.0.0'}
-    peerDependencies:
-      eslint: '>= 6'
-      typescript: '>= 2.7'
-      vue-template-compiler: '*'
-      webpack: '>= 4'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      vue-template-compiler:
-        optional: true
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@types/json-schema': 7.0.11
-      chalk: 4.1.2
-      chokidar: 3.5.3
-      cosmiconfig: 6.0.0
-      deepmerge: 4.3.0
-      eslint: 8.36.0
-      fs-extra: 9.1.0
-      glob: 7.2.3
-      memfs: 3.4.13
-      minimatch: 3.1.2
-      schema-utils: 2.7.0
-      semver: 7.3.8
-      tapable: 1.1.3
-      typescript: 5.0.2
-      webpack: 4.46.0
-    dev: true
-
-  /fork-ts-checker-webpack-plugin/6.5.3_h5wu2rkrstopp4ioziilohop5e:
-    resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
-    engines: {node: '>=10', yarn: '>=1.0.0'}
-    peerDependencies:
-      eslint: '>= 6'
-      typescript: '>= 2.7'
-      vue-template-compiler: '*'
-      webpack: '>= 4'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      vue-template-compiler:
-        optional: true
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@types/json-schema': 7.0.11
-      chalk: 4.1.2
-      chokidar: 3.5.3
-      cosmiconfig: 6.0.0
-      deepmerge: 4.3.0
-      eslint: 8.36.0
-      fs-extra: 9.1.0
-      glob: 7.2.3
-      memfs: 3.4.13
-      minimatch: 3.1.2
-      schema-utils: 2.7.0
-      semver: 7.3.8
-      tapable: 1.1.3
-      typescript: 5.0.2
-      webpack: 5.75.0
-
-  /fork-ts-checker-webpack-plugin/6.5.3_ikqt5m4x57vlca6bzw57fnhhpq:
+  /fork-ts-checker-webpack-plugin/6.5.3_evijigonbo4skk2vlqtwtdqibu:
     resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -21558,7 +20335,7 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.8
       tapable: 1.1.3
-      typescript: 5.0.2
+      typescript: 4.9.5
       webpack: 4.46.0
     dev: true
 
@@ -26340,7 +25117,7 @@ packages:
     resolution: {integrity: sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==}
     dev: true
 
-  /next/11.1.4_naxqhzibi624xxsjqpijhf76xq:
+  /next/11.1.4_6mbplxbx6s7x4hmdmervij2kcu:
     resolution: {integrity: sha512-GWQJrWYkfAKP8vmrzJcCfRSKv955Khyjqd5jipTcVKDGg+SH+NfjDMWFtCwArcQlHPvzisGu1ERLY0+Eoj7G+g==}
     engines: {node: '>=12.0.0'}
     hasBin: true
@@ -26391,7 +25168,7 @@ packages:
       os-browserify: 0.3.0
       p-limit: 3.1.0
       path-browserify: 1.0.1
-      pnp-webpack-plugin: 1.6.4_typescript@5.0.2
+      pnp-webpack-plugin: 1.6.4_typescript@4.9.5
       postcss: 8.2.15
       process: 0.11.10
       querystring-es3: 0.2.1
@@ -27971,15 +26748,6 @@ packages:
       ts-pnp: 1.2.0_typescript@4.9.5
     transitivePeerDependencies:
       - typescript
-    dev: true
-
-  /pnp-webpack-plugin/1.6.4_typescript@5.0.2:
-    resolution: {integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==}
-    engines: {node: '>=6'}
-    dependencies:
-      ts-pnp: 1.2.0_typescript@5.0.2
-    transitivePeerDependencies:
-      - typescript
 
   /pnp-webpack-plugin/1.7.0_typescript@4.2.4:
     resolution: {integrity: sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg==}
@@ -28004,15 +26772,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       ts-pnp: 1.2.0_typescript@4.9.5
-    transitivePeerDependencies:
-      - typescript
-    dev: true
-
-  /pnp-webpack-plugin/1.7.0_typescript@5.0.2:
-    resolution: {integrity: sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg==}
-    engines: {node: '>=6'}
-    dependencies:
-      ts-pnp: 1.2.0_typescript@5.0.2
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -30066,50 +28825,9 @@ packages:
     peerDependencies:
       react-scripts: '>=2.1.3'
     dependencies:
-      react-scripts: 5.0.1_wbhqbto5o2tdq7via3rqcfefny
+      react-scripts: 5.0.1_2c5defd7ngpxz5iugy7arqqahy
       semver: 5.7.1
     dev: true
-
-  /react-dev-utils/12.0.1_h5wu2rkrstopp4ioziilohop5e:
-    resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=2.7'
-      webpack: '>=4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      address: 1.2.2
-      browserslist: 4.21.5
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      detect-port-alt: 1.1.6
-      escape-string-regexp: 4.0.0
-      filesize: 8.0.7
-      find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3_h5wu2rkrstopp4ioziilohop5e
-      global-modules: 2.0.0
-      globby: 11.1.0
-      gzip-size: 6.0.0
-      immer: 9.0.19
-      is-root: 2.1.0
-      loader-utils: 3.2.1
-      open: 8.4.2
-      pkg-up: 3.1.0
-      prompts: 2.4.2
-      react-error-overlay: 6.0.11
-      recursive-readdir: 2.2.3
-      shell-quote: 1.8.0
-      strip-ansi: 6.0.1
-      text-table: 0.2.0
-      typescript: 5.0.2
-      webpack: 5.75.0
-    transitivePeerDependencies:
-      - eslint
-      - supports-color
-      - vue-template-compiler
 
   /react-dev-utils/12.0.1_ppjkfppa74pa6dp4kvr5fwj5re:
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
@@ -30168,14 +28886,6 @@ packages:
       typescript: '>= 4.3.x'
     dependencies:
       typescript: 4.9.5
-    dev: true
-
-  /react-docgen-typescript/2.2.2_typescript@5.0.2:
-    resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
-    peerDependencies:
-      typescript: '>= 4.3.x'
-    dependencies:
-      typescript: 5.0.2
     dev: true
 
   /react-docgen/5.4.3:
@@ -30534,7 +29244,7 @@ packages:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  /react-scripts/5.0.1_dpztdo7g75ohhwxcrpfkjai7wm:
+  /react-scripts/5.0.1_qmzmvk5l77gjs3zzl3vdy6ploi:
     resolution: {integrity: sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
@@ -30562,7 +29272,7 @@ packages:
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
       eslint: 8.36.0
-      eslint-config-react-app: 7.0.1_wqyc3vbambvdslb2tq3iw5m6b4
+      eslint-config-react-app: 7.0.1_rxzn5tawmjbqoelz7f53aidlo4
       eslint-webpack-plugin: 3.2.0_z62k3dgnr6jbdlqj2thrt6g3ii
       file-loader: 6.2.0_webpack@5.75.0
       fs-extra: 10.1.0
@@ -30578,19 +29288,19 @@ packages:
       postcss-normalize: 10.0.1_jrpp4geoaqu5dz2gragkckznb4
       postcss-preset-env: 7.8.3_postcss@8.4.21
       prompts: 2.4.2
-      react: 18.2.0
+      react: 16.14.0
       react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1_h5wu2rkrstopp4ioziilohop5e
+      react-dev-utils: 12.0.1_ppjkfppa74pa6dp4kvr5fwj5re
       react-refresh: 0.11.0
       resolve: 1.22.1
       resolve-url-loader: 4.0.0
-      sass-loader: 12.6.0_sass@1.58.3+webpack@5.75.0
+      sass-loader: 12.6.0_webpack@5.75.0
       semver: 7.3.8
       source-map-loader: 3.0.2_webpack@5.75.0
       style-loader: 3.3.1_webpack@5.75.0
       tailwindcss: 3.2.7_postcss@8.4.21
       terser-webpack-plugin: 5.3.6_webpack@5.75.0
-      typescript: 5.0.2
+      typescript: 4.9.5
       webpack: 5.75.0
       webpack-dev-server: 4.11.1_webpack@5.75.0
       webpack-manifest-plugin: 4.1.1_webpack@5.75.0
@@ -30631,7 +29341,7 @@ packages:
       - webpack-plugin-serve
     dev: false
 
-  /react-scripts/5.0.1_wbhqbto5o2tdq7via3rqcfefny:
+  /react-scripts/5.0.1_z7cyyy7aniencsdruwwbt2kbhm:
     resolution: {integrity: sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
@@ -30659,7 +29369,7 @@ packages:
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
       eslint: 8.36.0
-      eslint-config-react-app: 7.0.1_wqyc3vbambvdslb2tq3iw5m6b4
+      eslint-config-react-app: 7.0.1_rxzn5tawmjbqoelz7f53aidlo4
       eslint-webpack-plugin: 3.2.0_z62k3dgnr6jbdlqj2thrt6g3ii
       file-loader: 6.2.0_webpack@5.75.0
       fs-extra: 10.1.0
@@ -30677,113 +29387,17 @@ packages:
       prompts: 2.4.2
       react: 18.2.0
       react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1_h5wu2rkrstopp4ioziilohop5e
+      react-dev-utils: 12.0.1_ppjkfppa74pa6dp4kvr5fwj5re
       react-refresh: 0.11.0
       resolve: 1.22.1
       resolve-url-loader: 4.0.0
-      sass-loader: 12.6.0_webpack@5.75.0
+      sass-loader: 12.6.0_sass@1.58.3+webpack@5.75.0
       semver: 7.3.8
       source-map-loader: 3.0.2_webpack@5.75.0
       style-loader: 3.3.1_webpack@5.75.0
       tailwindcss: 3.2.7_postcss@8.4.21
       terser-webpack-plugin: 5.3.6_webpack@5.75.0
-      typescript: 5.0.2
-      webpack: 5.75.0
-      webpack-dev-server: 4.11.1_webpack@5.75.0
-      webpack-manifest-plugin: 4.1.1_webpack@5.75.0
-      workbox-webpack-plugin: 6.5.4_webpack@5.75.0
-    optionalDependencies:
-      fsevents: 2.3.2
-    transitivePeerDependencies:
-      - '@babel/plugin-syntax-flow'
-      - '@babel/plugin-transform-react-jsx'
-      - '@parcel/css'
-      - '@swc/core'
-      - '@types/babel__core'
-      - '@types/webpack'
-      - bufferutil
-      - canvas
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - fibers
-      - node-notifier
-      - node-sass
-      - rework
-      - rework-visit
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - ts-node
-      - type-fest
-      - uglify-js
-      - utf-8-validate
-      - vue-template-compiler
-      - webpack-cli
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  /react-scripts/5.0.1_yi7pi2hxako6ihbutpjt7r7sjq:
-    resolution: {integrity: sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
-    peerDependencies:
-      eslint: '*'
-      react: '>= 16 || ^18'
-      typescript: ^3.2.1 || ^4
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@babel/core': 7.21.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10_unmakpayn7vcxadrrsbqlrpehy
-      '@svgr/webpack': 5.5.0
-      babel-jest: 27.5.1_@babel+core@7.21.0
-      babel-loader: 8.3.0_qoaxtqicpzj5p3ubthw53xafqm
-      babel-plugin-named-asset-import: 0.3.8_@babel+core@7.21.0
-      babel-preset-react-app: 10.0.1
-      bfj: 7.0.2
-      browserslist: 4.21.5
-      camelcase: 6.3.0
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      css-loader: 6.7.3_webpack@5.75.0
-      css-minimizer-webpack-plugin: 3.4.1_webpack@5.75.0
-      dotenv: 10.0.0
-      dotenv-expand: 5.1.0
-      eslint: 8.36.0
-      eslint-config-react-app: 7.0.1_wqyc3vbambvdslb2tq3iw5m6b4
-      eslint-webpack-plugin: 3.2.0_z62k3dgnr6jbdlqj2thrt6g3ii
-      file-loader: 6.2.0_webpack@5.75.0
-      fs-extra: 10.1.0
-      html-webpack-plugin: 5.5.0_webpack@5.75.0
-      identity-obj-proxy: 3.0.0
-      jest: 27.5.1
-      jest-resolve: 27.5.1
-      jest-watch-typeahead: 1.1.0_jest@27.5.1
-      mini-css-extract-plugin: 2.7.3_webpack@5.75.0
-      postcss: 8.4.21
-      postcss-flexbugs-fixes: 5.0.2_postcss@8.4.21
-      postcss-loader: 6.2.1_6jdsrmfenkuhhw3gx4zvjlznce
-      postcss-normalize: 10.0.1_jrpp4geoaqu5dz2gragkckznb4
-      postcss-preset-env: 7.8.3_postcss@8.4.21
-      prompts: 2.4.2
-      react: 16.14.0
-      react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1_h5wu2rkrstopp4ioziilohop5e
-      react-refresh: 0.11.0
-      resolve: 1.22.1
-      resolve-url-loader: 4.0.0
-      sass-loader: 12.6.0_webpack@5.75.0
-      semver: 7.3.8
-      source-map-loader: 3.0.2_webpack@5.75.0
-      style-loader: 3.3.1_webpack@5.75.0
-      tailwindcss: 3.2.7_postcss@8.4.21
-      terser-webpack-plugin: 5.3.6_webpack@5.75.0
-      typescript: 5.0.2
+      typescript: 4.9.5
       webpack: 5.75.0
       webpack-dev-server: 4.11.1_webpack@5.75.0
       webpack-manifest-plugin: 4.1.1_webpack@5.75.0
@@ -33251,8 +31865,8 @@ packages:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 3.55.1
-      svelte-preprocess: 4.10.7_l6gh7invo235md22ird7wlz7xq
-      typescript: 5.0.2
+      svelte-preprocess: 4.10.7_4x7phaipmicbaooxtnresslofa
+      typescript: 4.9.5
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -33333,57 +31947,6 @@ packages:
       strip-indent: 3.0.0
       svelte: 3.55.1
       typescript: 4.9.5
-    dev: true
-
-  /svelte-preprocess/4.10.7_l6gh7invo235md22ird7wlz7xq:
-    resolution: {integrity: sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==}
-    engines: {node: '>= 9.11.2'}
-    requiresBuild: true
-    peerDependencies:
-      '@babel/core': ^7.10.2
-      coffeescript: ^2.5.1
-      less: ^3.11.3 || ^4.0.0
-      node-sass: '*'
-      postcss: ^7 || ^8
-      postcss-load-config: ^2.1.0 || ^3.0.0 || ^4.0.0
-      pug: ^3.0.0
-      sass: ^1.26.8
-      stylus: ^0.55.0
-      sugarss: ^2.0.0
-      svelte: ^3.23.0
-      typescript: ^3.9.5 || ^4.0.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      coffeescript:
-        optional: true
-      less:
-        optional: true
-      node-sass:
-        optional: true
-      postcss:
-        optional: true
-      postcss-load-config:
-        optional: true
-      pug:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@types/pug': 2.0.6
-      '@types/sass': 1.45.0
-      detect-indent: 6.1.0
-      magic-string: 0.25.9
-      sorcery: 0.10.0
-      strip-indent: 3.0.0
-      svelte: 3.55.1
-      typescript: 5.0.2
     dev: true
 
   /svelte/3.55.1:
@@ -34005,7 +32568,7 @@ packages:
       webpack: 5.75.0
     dev: true
 
-  /ts-node-dev/2.0.0_sxidjv3cojnrggmso45tj7hldi:
+  /ts-node-dev/2.0.0_cbfmry4sbbh4vatmdrsmatfg5a:
     resolution: {integrity: sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==}
     engines: {node: '>=0.8.0'}
     hasBin: true
@@ -34024,13 +32587,44 @@ packages:
       rimraf: 2.7.1
       source-map-support: 0.5.21
       tree-kill: 1.2.2
-      ts-node: 10.9.1_sxidjv3cojnrggmso45tj7hldi
+      ts-node: 10.9.1_cbfmry4sbbh4vatmdrsmatfg5a
       tsconfig: 7.0.0
-      typescript: 5.0.2
+      typescript: 4.9.5
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
+    dev: true
+
+  /ts-node/10.9.1_alpjt73dvgv6kni625hu7f2l4m:
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      '@types/node': 18.14.6
+      acorn: 8.8.2
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.9.5
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
     dev: true
 
   /ts-node/10.9.1_cbfmry4sbbh4vatmdrsmatfg5a:
@@ -34060,68 +32654,6 @@ packages:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 4.9.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
-
-  /ts-node/10.9.1_h3fbjg56t7r6gafnoy6qf2o25e:
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 18.14.6
-      acorn: 8.8.2
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.0.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
-
-  /ts-node/10.9.1_sxidjv3cojnrggmso45tj7hldi:
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 18.15.3
-      acorn: 8.8.2
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.0.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -34159,18 +32691,6 @@ packages:
         optional: true
     dependencies:
       typescript: 4.9.5
-    dev: true
-
-  /ts-pnp/1.2.0_typescript@5.0.2:
-    resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
-    engines: {node: '>=6'}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      typescript: 5.0.2
 
   /tsconfig-paths/3.14.2:
     resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}
@@ -34216,15 +32736,6 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.9.5
-
-  /tsutils/3.21.0_typescript@5.0.2:
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 5.0.2
 
   /tty-browserify/0.0.0:
     resolution: {integrity: sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==}
@@ -34415,11 +32926,6 @@ packages:
   /typescript/4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
-    hasBin: true
-
-  /typescript/5.0.2:
-    resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
-    engines: {node: '>=12.20'}
     hasBin: true
 
   /ua-parser-js/0.7.34:

--- a/properties/package.json
+++ b/properties/package.json
@@ -27,7 +27,7 @@
     "@previewjs/type-analyzer": "^6.0.4"
   },
   "devDependencies": {
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "unbuild": "^1.1.2",
     "vite": "^4.2.0",
     "vitest": "^0.29.3"

--- a/serializable-values/package.json
+++ b/serializable-values/package.json
@@ -27,7 +27,7 @@
     "@previewjs/type-analyzer": "^6.0.4",
     "assert-never": "^1.2.1",
     "prettier": "^2.8.4",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@types/prettier": "^2.7.2",

--- a/storybook-helpers/package.json
+++ b/storybook-helpers/package.json
@@ -26,7 +26,7 @@
     "@previewjs/core": "^19.0.1",
     "@previewjs/serializable-values": "^5.0.1",
     "@previewjs/type-analyzer": "^6.0.4",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@previewjs/vfs": "workspace:*",

--- a/testing/package.json
+++ b/testing/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@types/fs-extra": "^11.0.1",
     "rimraf": "^4.4.0",
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "unbuild": "^1.1.2"
   }
 }

--- a/type-analyzer/package.json
+++ b/type-analyzer/package.json
@@ -26,7 +26,7 @@
     "@previewjs/vfs": "^2.0.1",
     "assert-never": "^1.2.1",
     "prettier": "^2.8.4",
-    "typescript": "^5.0.2"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.191",

--- a/vfs/package.json
+++ b/vfs/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.1",
-    "typescript": "^5.0.2",
+    "typescript": "^4.9.5",
     "unbuild": "^1.1.2",
     "vite": "^4.2.0",
     "vitest": "^0.29.3"


### PR DESCRIPTION
JSX function signatures are now detected as `any` in some projects such as https://github.com/alveshelio/solidjs-previewjs.