### PR TITLE
fix: do not generate `| undefined` for optional fields

### DIFF
--- a/frameworks/react/src/analyze-component.ts
+++ b/frameworks/react/src/analyze-component.ts
@@ -1,14 +1,15 @@
 import type { ComponentAnalysis } from "@previewjs/core";
+import type { CollectedTypes, ValueType } from "@previewjs/type-analyzer";
 import {
   dereferenceType,
   EMPTY_OBJECT_TYPE,
   maybeOptionalType,
   objectType,
+  OptionalType,
   stripUnusedTypes,
   TypeResolver,
   UNKNOWN_TYPE,
 } from "@previewjs/type-analyzer";
-import type { CollectedTypes, ValueType } from "@previewjs/type-analyzer";
 import ts from "typescript";
 import { detectPropTypes } from "./prop-types.js";
 
@@ -128,7 +129,7 @@ function computePropsTypeFromPropTypes(
   collected: CollectedTypes;
 } {
   const type = typeResolver.checker.getTypeAtLocation(propTypes);
-  const fields: Record<string, ValueType> = {};
+  const fields: Record<string, ValueType | OptionalType> = {};
   let collected: CollectedTypes = {};
   for (const property of type.getProperties()) {
     fields[property.name] = (() => {

--- a/frameworks/svelte/src/analyze-component.ts
+++ b/frameworks/svelte/src/analyze-component.ts
@@ -1,10 +1,11 @@
 import type { ComponentAnalysis } from "@previewjs/core";
+import type { CollectedTypes, ValueType } from "@previewjs/type-analyzer";
 import {
   maybeOptionalType,
   objectType,
+  OptionalType,
   TypeAnalyzer,
 } from "@previewjs/type-analyzer";
-import type { ValueType, CollectedTypes } from "@previewjs/type-analyzer";
 import ts from "typescript";
 
 export function analyzeSvelteComponentFromSFC(
@@ -13,7 +14,7 @@ export function analyzeSvelteComponentFromSFC(
 ): ComponentAnalysis {
   const resolver = typeAnalyzer.analyze([filePath + ".ts"]);
   const sourceFile = resolver.sourceFile(filePath + ".ts");
-  const propsTypeFields: Record<string, ValueType> = {};
+  const propsTypeFields: Record<string, ValueType | OptionalType> = {};
   let collected: CollectedTypes = {};
   for (const statement of sourceFile?.statements || []) {
     if (

--- a/frameworks/vue3/src/analyze-component.ts
+++ b/frameworks/vue3/src/analyze-component.ts
@@ -1,12 +1,12 @@
 import type { ComponentAnalysis } from "@previewjs/core";
+import type { CollectedTypes, ValueType } from "@previewjs/type-analyzer";
 import {
+  maybeOptionalType,
   objectType,
-  optionalType,
   TypeResolver,
   UNKNOWN_TYPE,
 } from "@previewjs/type-analyzer";
 import ts from "typescript";
-import type { CollectedTypes, ValueType } from "@previewjs/type-analyzer";
 
 export function analyzeVueComponentFromTemplate(
   resolver: TypeResolver,
@@ -128,9 +128,10 @@ function extractDefinePropsFromExpression(
           Object.entries(definePropsType.type.fields).map(
             ([fieldKey, fieldType]) => [
               fieldKey,
-              fieldsWithDefaultValue.has(fieldKey)
-                ? optionalType(fieldType)
-                : fieldType,
+              maybeOptionalType(
+                fieldType,
+                fieldsWithDefaultValue.has(fieldKey)
+              ),
             ]
           )
         )

--- a/properties/src/generate-callback-props.ts
+++ b/properties/src/generate-callback-props.ts
@@ -26,6 +26,9 @@ export function generateCallbackProps(
   let text = "";
   text += "{";
   for (const [propertyName, propertyType] of Object.entries(propsType.fields)) {
+    if (propertyType.kind === "optional") {
+      continue;
+    }
     const resolvedPropertyType = resolveType(propertyType);
     if (resolvedPropertyType.kind === "function") {
       propKeys.add(propertyName);

--- a/serializable-values/src/generate-serializable-value.ts
+++ b/serializable-values/src/generate-serializable-value.ts
@@ -140,8 +140,13 @@ function _generateSerializableValue(
     case "object": {
       const entries: SerializableObjectValueEntry[] = [];
       for (const [propName, propType] of Object.entries(type.fields)) {
+        let nonOptionalPropType =
+          propType.kind === "optional" ? propType.type : propType;
+        if (propType.kind === "optional" && (!random || Math.random() < 0.5)) {
+          continue;
+        }
         const propValue = _generateSerializableValue(
-          propType,
+          nonOptionalPropType,
           collected,
           propName,
           rejectTypeNames,
@@ -242,18 +247,6 @@ function _generateSerializableValue(
         )
       );
     }
-    case "optional":
-      if (random && Math.random() < 0.5) {
-        return _generateSerializableValue(
-          type.type,
-          collected,
-          fieldName,
-          rejectTypeNames,
-          random,
-          isFunctionReturnValue
-        );
-      }
-      return UNDEFINED;
     case "promise": {
       return promise({
         type: "reject",

--- a/type-analyzer/src/analyzer.spec.ts
+++ b/type-analyzer/src/analyzer.spec.ts
@@ -10,8 +10,14 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import type { TypeAnalyzer } from ".";
 import {
   ANY_TYPE,
-  arrayType,
   BOOLEAN_TYPE,
+  NODE_TYPE,
+  NULL_TYPE,
+  NUMBER_TYPE,
+  STRING_TYPE,
+  UNKNOWN_TYPE,
+  VOID_TYPE,
+  arrayType,
   createTypeAnalyzer,
   enumType,
   functionType,
@@ -19,19 +25,13 @@ import {
   literalType,
   mapType,
   namedType,
-  NODE_TYPE,
-  NULL_TYPE,
-  NUMBER_TYPE,
   objectType,
   optionalType,
   promiseType,
   recordType,
   setType,
-  STRING_TYPE,
   tupleType,
   unionType,
-  UNKNOWN_TYPE,
-  VOID_TYPE,
 } from ".";
 
 describe.concurrent("TypeAnalyzer", () => {
@@ -596,7 +596,7 @@ type B = {
       namedType("main.ts:A"),
       {
         "main.ts:A": {
-          type: optionalType(namedType("main.ts:B")),
+          type: unionType([VOID_TYPE, namedType("main.ts:B")]),
           parameters: {},
         },
         "main.ts:B": {
@@ -625,7 +625,7 @@ type B = {
       namedType("main.ts:A"),
       {
         "main.ts:A": {
-          type: optionalType(namedType("main.ts:B")),
+          type: unionType([VOID_TYPE, namedType("main.ts:B")]),
           parameters: {},
         },
         "main.ts:B": {
@@ -665,7 +665,7 @@ foo: string;
       namedType("main.ts:A"),
       {
         "main.ts:A": {
-          type: optionalType(unionType([NULL_TYPE, namedType("main.ts:B")])),
+          type: unionType([VOID_TYPE, NULL_TYPE, namedType("main.ts:B")]),
           parameters: {},
         },
         "main.ts:B": {

--- a/type-analyzer/src/analyzer.ts
+++ b/type-analyzer/src/analyzer.ts
@@ -3,31 +3,31 @@ import path from "path";
 import ts from "typescript";
 import {
   ANY_TYPE,
-  arrayType,
   BOOLEAN_TYPE,
+  CollectedTypes,
   EMPTY_OBJECT_TYPE,
+  NEVER_TYPE,
+  NULL_TYPE,
+  NUMBER_TYPE,
+  OptionalType,
+  ParameterizableType,
+  STRING_TYPE,
+  UNKNOWN_TYPE,
+  VOID_TYPE,
+  ValueType,
+  arrayType,
   enumType,
   functionType,
   literalType,
   mapType,
   maybeOptionalType,
   namedType,
-  NEVER_TYPE,
-  NULL_TYPE,
-  NUMBER_TYPE,
   objectType,
   promiseType,
   recordType,
   setType,
-  STRING_TYPE,
   tupleType,
-  UNKNOWN_TYPE,
-  VOID_TYPE,
-} from "./definitions";
-import type {
-  CollectedTypes,
-  ParameterizableType,
-  ValueType,
+  unionType,
 } from "./definitions";
 import { computeIntersection } from "./intersection";
 import { stripUnusedTypes } from "./strip-unused-types";
@@ -459,7 +459,7 @@ class TypeResolver {
           this.resolveTypeInternal(indexType, genericTypeNames)
         );
       }
-      const fields: Record<string, ValueType> = {};
+      const fields: Record<string, ValueType | OptionalType> = {};
       for (const property of type.getProperties()) {
         const [propertyName, ...nestedPath] = property.name.split(".");
         if (nestedPath.length > 0) {
@@ -509,12 +509,18 @@ class TypeResolver {
             property.name
           );
         }
-        fields[propertyName!] = maybeOptionalType(
-          propertyTsType
-            ? this.resolveTypeInternal(propertyTsType, genericTypeNames)
-            : UNKNOWN_TYPE,
-          Boolean(property.flags & ts.SymbolFlags.Optional)
-        );
+        let fieldType = propertyTsType
+          ? this.resolveTypeInternal(propertyTsType, genericTypeNames)
+          : UNKNOWN_TYPE;
+        const optional = Boolean(property.flags & ts.SymbolFlags.Optional);
+        if (optional) {
+          if (fieldType.kind === "union") {
+            fieldType = unionType(
+              fieldType.types.filter((t) => t.kind !== "void")
+            );
+          }
+        }
+        fields[propertyName!] = maybeOptionalType(fieldType, optional);
       }
       return objectType(fields);
     }

--- a/type-analyzer/src/definitions.ts
+++ b/type-analyzer/src/definitions.ts
@@ -212,9 +212,12 @@ export function optionalType(type: ValueType): OptionalType {
   };
 }
 export function maybeOptionalType(
-  type: ValueType,
+  type: ValueType | OptionalType,
   optional: boolean
 ): ValueType | OptionalType {
+  if (type.kind === "optional") {
+    return type;
+  }
   if (optional) {
     return optionalType(type);
   }

--- a/type-analyzer/src/definitions.ts
+++ b/type-analyzer/src/definitions.ts
@@ -19,7 +19,6 @@ export type ValueType =
   | UnionType
   | IntersectionType
   | FunctionType
-  | OptionalType
   | PromiseType
   | NamedType;
 
@@ -87,10 +86,10 @@ export function enumType(options: {
 
 export interface ObjectType {
   kind: "object";
-  fields: { [fieldName: string]: ValueType };
+  fields: { [fieldName: string]: ValueType | OptionalType };
 }
 export function objectType(fields: {
-  [fieldName: string]: ValueType;
+  [fieldName: string]: ValueType | OptionalType;
 }): ObjectType {
   return {
     kind: "object",
@@ -207,9 +206,6 @@ export interface OptionalType {
   type: ValueType;
 }
 export function optionalType(type: ValueType): OptionalType {
-  if (type.kind === "optional") {
-    return type;
-  }
   return {
     kind: "optional",
     type,
@@ -218,10 +214,7 @@ export function optionalType(type: ValueType): OptionalType {
 export function maybeOptionalType(
   type: ValueType,
   optional: boolean
-): ValueType {
-  if (type.kind === "optional") {
-    return type;
-  }
+): ValueType | OptionalType {
   if (optional) {
     return optionalType(type);
   }

--- a/type-analyzer/src/definitions.ts
+++ b/type-analyzer/src/definitions.ts
@@ -213,13 +213,21 @@ export function optionalType(type: ValueType): OptionalType {
 }
 export function maybeOptionalType(
   type: ValueType | OptionalType,
-  optional: boolean
+  optional = false
 ): ValueType | OptionalType {
   if (type.kind === "optional") {
     return type;
   }
   if (optional) {
     return optionalType(type);
+  }
+  if (type.kind === "union") {
+    const hasVoid = type.types.findIndex((t) => t.kind === "void");
+    if (hasVoid !== -1) {
+      return optionalType(
+        unionType(type.types.filter((t) => t.kind !== "void"))
+      );
+    }
   }
   return type;
 }

--- a/type-analyzer/src/dereference.ts
+++ b/type-analyzer/src/dereference.ts
@@ -1,6 +1,6 @@
 import assertNever from "assert-never";
-import { EMPTY_OBJECT_TYPE, optionalType, UNKNOWN_TYPE } from "./definitions";
 import type { CollectedTypes, ValueType } from "./definitions";
+import { EMPTY_OBJECT_TYPE, UNKNOWN_TYPE } from "./definitions";
 import { computeIntersection } from "./intersection";
 import { evaluateType } from "./type-parameters";
 import { computeUnion } from "./union";
@@ -63,14 +63,6 @@ export function dereferenceType(
         encountered.push(...encounteredInSubtype);
       }
       return [computeIntersection(subtypes), encountered];
-    }
-    case "optional": {
-      const [resolved, encountered] = dereferenceType(
-        type.type,
-        collected,
-        rejectTypeNames
-      );
-      return [optionalType(resolved), encountered];
     }
     case "name": {
       if (rejectTypeNames.includes(type.name)) {

--- a/type-analyzer/src/generate-type-declarations.spec.ts
+++ b/type-analyzer/src/generate-type-declarations.spec.ts
@@ -1,27 +1,27 @@
 import { describe, expect, test } from "vitest";
 import {
   ANY_TYPE,
-  arrayType,
   BOOLEAN_TYPE,
+  NEVER_TYPE,
+  NODE_TYPE,
+  NULL_TYPE,
+  NUMBER_TYPE,
+  STRING_TYPE,
+  UNKNOWN_TYPE,
+  VOID_TYPE,
+  arrayType,
   enumType,
   functionType,
   intersectionType,
   literalType,
   namedType,
-  NEVER_TYPE,
-  NODE_TYPE,
-  NULL_TYPE,
-  NUMBER_TYPE,
   objectType,
   optionalType,
   promiseType,
   recordType,
   setType,
-  STRING_TYPE,
   tupleType,
   unionType,
-  UNKNOWN_TYPE,
-  VOID_TYPE,
 } from "./definitions";
 import { generateTypeDeclarations } from "./generate-type-declarations";
 
@@ -69,7 +69,7 @@ describe("generateTypeDeclarations", () => {
       })
     ).toMatchInlineSnapshot(`
       "type Foo = {
-        [\\"child\\"]?: Foo | undefined;
+        [\\"child\\"]?: Foo;
         [\\"children\\"]: Array<Foo>;
       };"
     `);
@@ -85,7 +85,7 @@ describe("generateTypeDeclarations", () => {
           parameters: {},
         },
         "/foo.tsx:Fn": {
-          type: functionType(optionalType(namedType("/foo.tsx:Fn"))),
+          type: functionType(unionType([VOID_TYPE, namedType("/foo.tsx:Fn")])),
           parameters: {},
         },
       })
@@ -94,7 +94,7 @@ describe("generateTypeDeclarations", () => {
         [\\"foo\\"]: Fn;
       };
 
-      type Fn = (...params: any[]) => Fn | undefined;"
+      type Fn = (...params: any[]) => void | Fn;"
     `);
   });
 
@@ -234,11 +234,11 @@ describe("generateTypeDeclarations", () => {
     ).toMatchInlineSnapshot(`
       "type Foo = {
         [\\"a\\"]: string;
-        [\\"b\\"]?: string | undefined;
+        [\\"b\\"]?: string;
         [\\"c\\"]?: any;
         [\\"d\\"]?: unknown;
         [\\"e\\"]: string;
-        [\\"f\\"]?: string | undefined;
+        [\\"f\\"]?: string;
       };"
     `);
   });

--- a/type-analyzer/src/generate-type-declarations.ts
+++ b/type-analyzer/src/generate-type-declarations.ts
@@ -143,13 +143,13 @@ function generateTypeScriptType(
                       ? collected[propType.name]?.type || propType
                       : propType;
                   const optional =
-                    resolvedPropType.kind === "optional" ||
+                    propType.kind === "optional" ||
                     resolvedPropType.kind === "any" ||
                     resolvedPropType.kind === "unknown";
                   return `["${propName.replace(/"/g, '\\"')}"]${
                     optional ? "?" : ""
                   }: ${generateTypeScriptType(
-                    propType,
+                    propType.kind === "optional" ? propType.type : propType,
                     collected,
                     typeNameMapping,
                     usedTypes
@@ -212,13 +212,6 @@ function generateTypeScriptType(
         typeNameMapping,
         usedTypes
       )})`;
-    case "optional":
-      return `${generateTypeScriptType(
-        type.type,
-        collected,
-        typeNameMapping,
-        usedTypes
-      )} | undefined`;
     case "promise":
       return `Promise<${generateTypeScriptType(
         type.type,

--- a/type-analyzer/src/intersection.ts
+++ b/type-analyzer/src/intersection.ts
@@ -2,6 +2,8 @@ import isEqual from "lodash/isEqual";
 import {
   functionType,
   intersectionType,
+  maybeOptionalType,
+  OptionalType,
   unionType,
   ValueType,
   VOID_TYPE,
@@ -49,7 +51,8 @@ export function computeIntersection(types: ValueType[]): ValueType {
         if (intersectWith.kind !== "object") {
           return defaultIntersection;
         }
-        const intersectingFields: Array<[string, ValueType]> = [];
+        const intersectingFields: Array<[string, ValueType | OptionalType]> =
+          [];
         for (const fieldName of new Set([
           ...Object.keys(evolvingType.fields),
           ...Object.keys(intersectWith.fields),
@@ -76,7 +79,7 @@ export function computeIntersection(types: ValueType[]): ValueType {
               `Could not compute type of intersection field ${fieldName}`
             );
           }
-          intersectingFields.push([fieldName, fieldType]);
+          intersectingFields.push([fieldName, maybeOptionalType(fieldType)]);
         }
         evolvingType = {
           kind: "object",

--- a/type-analyzer/src/intersection.ts
+++ b/type-analyzer/src/intersection.ts
@@ -1,6 +1,11 @@
 import isEqual from "lodash/isEqual";
-import { functionType, intersectionType, VOID_TYPE } from "./definitions";
-import type { ValueType } from "./definitions";
+import {
+  functionType,
+  intersectionType,
+  unionType,
+  ValueType,
+  VOID_TYPE,
+} from "./definitions";
 
 export function computeIntersection(types: ValueType[]): ValueType {
   types = types.filter((type, i) => {
@@ -49,8 +54,17 @@ export function computeIntersection(types: ValueType[]): ValueType {
           ...Object.keys(evolvingType.fields),
           ...Object.keys(intersectWith.fields),
         ])) {
-          const evolvingFieldType = evolvingType.fields[fieldName];
-          const intersectingFieldType = intersectWith.fields[fieldName];
+          const maybeOptionalEvolvingFieldType = evolvingType.fields[fieldName];
+          const maybeOptionalIntersectingFieldType =
+            intersectWith.fields[fieldName];
+          const evolvingFieldType =
+            maybeOptionalEvolvingFieldType?.kind === "optional"
+              ? unionType([VOID_TYPE, maybeOptionalEvolvingFieldType.type])
+              : maybeOptionalEvolvingFieldType;
+          const intersectingFieldType =
+            maybeOptionalIntersectingFieldType?.kind === "optional"
+              ? unionType([VOID_TYPE, maybeOptionalIntersectingFieldType.type])
+              : maybeOptionalIntersectingFieldType;
           const fieldType =
             evolvingFieldType && intersectingFieldType
               ? computeIntersection([evolvingFieldType, intersectingFieldType])

--- a/type-analyzer/src/is-valid.ts
+++ b/type-analyzer/src/is-valid.ts
@@ -75,7 +75,12 @@ export function isValid(
       }
       for (const [propName, propType] of Object.entries(type.fields)) {
         const propValue = value[propName];
-        if (!isValid(propType, collected, propValue)) {
+        if (propType.kind === "optional" && value === undefined) {
+          return true;
+        }
+        const nonOptionalPropType =
+          propType.kind === "optional" ? propType.type : propType;
+        if (!isValid(nonOptionalPropType, collected, propValue)) {
           return false;
         }
       }
@@ -122,8 +127,6 @@ export function isValid(
       return true;
     case "function":
       return typeof value === "function";
-    case "optional":
-      return value === undefined || isValid(type.type, collected, value);
     case "promise":
       return value && typeof value === "object" && "then" in value;
     case "name": {

--- a/type-analyzer/src/strip-unused-types.ts
+++ b/type-analyzer/src/strip-unused-types.ts
@@ -34,7 +34,7 @@ export function stripUnusedTypes(collected: CollectedTypes, type: ValueType) {
         return;
       case "object":
         for (const fieldType of Object.values(type.fields)) {
-          visitType(fieldType);
+          visitType(fieldType.kind === "optional" ? fieldType.type : fieldType);
         }
         return;
       case "map":
@@ -46,7 +46,6 @@ export function stripUnusedTypes(collected: CollectedTypes, type: ValueType) {
         visitType(type.returnType);
         return;
       case "promise":
-      case "optional":
         visitType(type.type);
         return;
       case "union":

--- a/type-analyzer/src/type-parameters.ts
+++ b/type-analyzer/src/type-parameters.ts
@@ -1,17 +1,17 @@
 import assertNever from "assert-never";
+import type { ParameterizableType, ValueType } from "./definitions";
 import {
   arrayType,
   functionType,
   mapType,
+  maybeOptionalType,
   objectType,
-  optionalType,
   promiseType,
   recordType,
   setType,
   tupleType,
   UNKNOWN_TYPE,
 } from "./definitions";
-import type { ParameterizableType, ValueType } from "./definitions";
 import { computeIntersection } from "./intersection";
 import { computeUnion } from "./union";
 
@@ -88,7 +88,14 @@ function replaceNamedType(
         Object.fromEntries(
           Object.entries(type.fields).map(([key, fieldType]) => [
             key,
-            replaceNamedType(fieldType, named, replacement),
+            maybeOptionalType(
+              replaceNamedType(
+                fieldType.kind === "optional" ? fieldType.type : fieldType,
+                named,
+                replacement
+              ),
+              fieldType.kind === "optional"
+            ),
           ])
         )
       );
@@ -104,8 +111,6 @@ function replaceNamedType(
       return functionType(
         replaceNamedType(type.returnType, named, replacement)
       );
-    case "optional":
-      return optionalType(replaceNamedType(type.type, named, replacement));
     case "promise":
       return promiseType(replaceNamedType(type.type, named, replacement));
     case "name":

--- a/type-analyzer/src/union.ts
+++ b/type-analyzer/src/union.ts
@@ -1,26 +1,9 @@
 import isEqual from "lodash/isEqual";
 import { BOOLEAN_TYPE } from ".";
-import {
-  functionType,
-  maybeOptionalType,
-  unionType,
-  VOID_TYPE,
-} from "./definitions";
 import type { ValueType } from "./definitions";
+import { functionType, unionType, VOID_TYPE } from "./definitions";
 
 export function computeUnion(types: ValueType[]): ValueType {
-  let hasVoid = false;
-  types = types.filter((t) => {
-    if (t.kind === "void") {
-      hasVoid = true;
-      return false;
-    }
-    return true;
-  });
-  return maybeOptionalType(computeUnionWithoutVoid(types), hasVoid);
-}
-
-function computeUnionWithoutVoid(types: ValueType[]): ValueType {
   const evolvingType = types[0];
   if (!evolvingType) {
     return VOID_TYPE;
@@ -41,7 +24,7 @@ function computeUnionWithoutVoid(types: ValueType[]): ValueType {
   );
   const hasTrue = !!types.find((t) => t.kind === "literal" && t.value === true);
   if (hasFalse && hasTrue) {
-    return computeUnionWithoutVoid([
+    return computeUnion([
       BOOLEAN_TYPE,
       ...types.filter(
         (t) => t.kind !== "literal" || typeof t.value !== "boolean"


### PR DESCRIPTION
This also removes `OptionalType` as a top-level type. It can only appear within an `ObjectType`'s fields.

@KrofDrakula FYI this is a small breaking change when dealing with object types.