### PR TITLE
chore: remove automatic sorting of components

### DIFF
--- a/core/src/detect-components.ts
+++ b/core/src/detect-components.ts
@@ -104,9 +104,6 @@ export function detectComponents(
       changedAbsoluteFilePaths
     );
     const components = [...recycledComponents, ...refreshedComponents];
-    components.sort((a, b) => {
-      return a.componentId.localeCompare(b.componentId);
-    });
     if (!options.filePaths) {
       await fs.mkdirp(path.dirname(cacheFilePath));
       const updatedCache: CachedProjectComponents = {


### PR DESCRIPTION
There is value in preserving the code-defined order of components and stories.