### PR TITLE
chore: remove duplicate uncaught error handling

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -33,7 +33,11 @@ const require = createRequire(import.meta.url);
 
 process.on("uncaughtException", (e) => {
   // eslint-disable-next-line no-console
-  console.error("Uncaught Exception:", e);
+  console.error("Encountered an uncaught exception", e);
+});
+process.on("unhandledRejection", (e) => {
+  // eslint-disable-next-line no-console
+  console.error("Encountered an unhandled promise", e);
 });
 
 export async function createWorkspace({

--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -103,16 +103,6 @@ if (logFilePath) {
   process.stdout.write = wrapProcessStreamWriter(
     process.stdout.write.bind(process.stdout)
   );
-  process.on("uncaughtException", (e) => {
-    // eslint-disable-next-line no-console
-    console.error("Encountered an uncaught exception", e);
-    process.exit(1);
-  });
-  process.on("unhandledRejection", (e) => {
-    // eslint-disable-next-line no-console
-    console.error("Encountered an unhandled promise", e);
-    process.exit(1);
-  });
 }
 
 export interface DaemonStartOptions {


### PR DESCRIPTION
This may be why PostCSS configuration errors sometimes cause the Preview.js server process to exit early.