### PR TITLE
fix(intellij): invalidate inlay hints once computed components have been updated

### DIFF
--- a/integrations/intellij/src/main/kotlin/com/previewjs/intellij/plugin/services/ProjectService.kt
+++ b/integrations/intellij/src/main/kotlin/com/previewjs/intellij/plugin/services/ProjectService.kt
@@ -1,5 +1,6 @@
 package com.previewjs.intellij.plugin.services
 
+import com.intellij.codeInsight.hints.InlayHintsPassFactory
 import com.intellij.execution.filters.TextConsoleBuilderFactory
 import com.intellij.execution.ui.ConsoleView
 import com.intellij.execution.ui.ConsoleViewContentType
@@ -150,6 +151,9 @@ class ProjectService(private val project: Project) : Disposable {
         val text = file.readText()
         computeComponents(file, text) { components ->
             componentMap[file.path] = Pair(text, components)
+            ApplicationManager.getApplication().invokeLater {
+                InlayHintsPassFactory.forceHintsUpdateOnNextPass()
+            }
         }
     }
 


### PR DESCRIPTION
See https://intellij-support.jetbrains.com/hc/en-us/community/posts/4968667359122-Restarting-inlay-hints-provider?page=1#community_comment_11888562167314