### PR TITLE
perf: prevent unnecessary in-memory file tracking

### DIFF
--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -46,12 +46,6 @@
     "configuration": {
       "title": "Preview.js",
       "properties": {
-        "previewjs.livePreview": {
-          "title": "Live Preview",
-          "type": "boolean",
-          "default": true,
-          "description": "Update previews instantly, without waiting for saving. Reload required."
-        },
         "previewjs.codelens": {
           "title": "CodeLens",
           "type": "boolean",

--- a/integrations/vscode/src/state.ts
+++ b/integrations/vscode/src/state.ts
@@ -35,7 +35,12 @@ export async function createState({
     outputChannel,
     workspaces
   );
-  const getComponents = createComponentDetector(daemon.client, getWorkspaceId);
+  const pendingFileChanges = new Map<string, string>();
+  const getComponents = createComponentDetector(
+    daemon.client,
+    getWorkspaceId,
+    pendingFileChanges
+  );
   const state: PreviewJsState = {
     client: daemon.client,
     dispose: () => {
@@ -46,6 +51,7 @@ export async function createState({
       }
     },
     workspaces,
+    pendingFileChanges,
     getComponents,
     getWorkspaceId,
     previewPanel: null,
@@ -58,6 +64,7 @@ export type PreviewJsState = {
   client: Client;
   dispose: () => void;
   workspaces: Workspaces;
+  pendingFileChanges: Map<string, string>;
   previewPanel: vscode.WebviewPanel | null;
   currentPreview: {
     workspaceId: string;

--- a/loader/src/runner.ts
+++ b/loader/src/runner.ts
@@ -32,12 +32,17 @@ export async function load({
     packageName,
   });
   const memoryReader = vfs.createMemoryReader();
-  const reader = vfs.createStackedReader([
-    memoryReader,
-    vfs.createFileSystemReader({
-      watch: true,
-    }),
-  ]);
+  const fsReader = vfs.createFileSystemReader({
+    watch: true,
+  });
+  fsReader.listeners.add({
+    onChange(absoluteFilePath, info) {
+      if (!info.virtual) {
+        memoryReader.updateFile(absoluteFilePath, null);
+      }
+    },
+  });
+  const reader = vfs.createStackedReader([memoryReader, fsReader]);
   const workspaces: {
     [rootDirPath: string]: core.Workspace | null;
   } = {};


### PR DESCRIPTION
This also removes the "livePreview" setting in VS Code, which would break inlay hints when disabled when the file is edited but not saved.