### PR TITLE
refactor: instantiate TypeAnalyzer within each framework plugin

### DIFF
--- a/chromeless/src/workspace.ts
+++ b/chromeless/src/workspace.ts
@@ -42,6 +42,7 @@ export async function createChromelessWorkspace({
   const frameworkPlugin = await setupFrameworkPlugin({
     rootDirPath,
     frameworkPlugins,
+    reader,
     logger,
   });
   if (!frameworkPlugin) {

--- a/core/src/detect-components.ts
+++ b/core/src/detect-components.ts
@@ -1,5 +1,4 @@
 import { RPCs, decodeComponentId } from "@previewjs/api";
-import type { TypeAnalyzer } from "@previewjs/type-analyzer";
 import { exclusivePromiseRunner } from "exclusive-promises";
 import fs from "fs-extra";
 import path from "path";
@@ -31,7 +30,6 @@ export function detectComponents(
   logger: Logger,
   workspace: Workspace,
   frameworkPlugin: FrameworkPlugin,
-  typeAnalyzer: TypeAnalyzer,
   options: {
     filePaths?: string[];
     forceRefresh?: boolean;
@@ -120,7 +118,6 @@ export function detectComponents(
       logger,
       workspace,
       frameworkPlugin,
-      typeAnalyzer,
       changedAbsoluteFilePaths
     );
     const components = [...recycledComponents, ...refreshedComponents];
@@ -140,7 +137,6 @@ async function detectComponentsCore(
   logger: Logger,
   workspace: Workspace,
   frameworkPlugin: FrameworkPlugin,
-  typeAnalyzer: TypeAnalyzer,
   changedAbsoluteFilePaths: string[]
 ): Promise<RPCs.Component[]> {
   const components: RPCs.Component[] = [];
@@ -155,8 +151,6 @@ async function detectComponentsCore(
       .join("\n- ")}`
   );
   const found = await frameworkPlugin.detectComponents(
-    workspace.reader,
-    typeAnalyzer,
     changedAbsoluteFilePaths
   );
   logger.debug(`Done running component detection`);

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -69,9 +69,6 @@ export async function createWorkspace({
       `Preview.js framework plugin ${frameworkPlugin.name} is too recent. Please upgrade Preview.js or use an older version of ${frameworkPlugin.name}.`
     );
   }
-  if (frameworkPlugin.transformReader) {
-    reader = frameworkPlugin.transformReader(reader);
-  }
   const router = new ApiRouter(logger);
   router.registerRPC(RPCs.ComputeProps, async ({ componentIds }) => {
     logger.debug(`Computing props for components: ${componentIds.join(", ")}`);

--- a/core/src/plugins/framework.ts
+++ b/core/src/plugins/framework.ts
@@ -6,7 +6,6 @@ import type {
 } from "@previewjs/type-analyzer";
 import type { Reader } from "@previewjs/vfs";
 import type { Logger } from "pino";
-import type ts from "typescript";
 import type vite from "vite";
 import type { PackageDependencies } from "./dependencies";
 
@@ -14,6 +13,7 @@ export interface FrameworkPluginFactory {
   isCompatible(dependencies: PackageDependencies): Promise<boolean>;
   create(options: {
     rootDirPath: string;
+    reader: Reader;
     logger: Logger;
     dependencies: PackageDependencies;
   }): Promise<FrameworkPlugin>;
@@ -25,12 +25,9 @@ export interface FrameworkPlugin {
   readonly defaultWrapperPath: string;
   readonly previewDirPath: string;
   readonly transformReader?: (reader: Reader) => Reader;
-  readonly tsCompilerOptions?: Partial<ts.CompilerOptions>;
-  readonly specialTypes?: Record<string, ValueType>;
+  readonly typeAnalyzer: TypeAnalyzer;
   readonly viteConfig: (configuredPlugins: vite.Plugin[]) => vite.UserConfig;
   readonly detectComponents: (
-    reader: Reader,
-    typeAnalyzer: TypeAnalyzer,
     absoluteFilePaths: string[]
   ) => Promise<AnalyzableComponent[]>;
 }

--- a/core/src/plugins/framework.ts
+++ b/core/src/plugins/framework.ts
@@ -24,7 +24,6 @@ export interface FrameworkPlugin {
   readonly name: string;
   readonly defaultWrapperPath: string;
   readonly previewDirPath: string;
-  readonly transformReader?: (reader: Reader) => Reader;
   readonly typeAnalyzer: TypeAnalyzer;
   readonly viteConfig: (configuredPlugins: vite.Plugin[]) => vite.UserConfig;
   readonly detectComponents: (

--- a/core/src/plugins/setup-framework-plugin.ts
+++ b/core/src/plugins/setup-framework-plugin.ts
@@ -1,3 +1,4 @@
+import type { Reader } from "@previewjs/vfs";
 import fs from "fs-extra";
 import { createRequire } from "module";
 import path from "path";
@@ -10,10 +11,12 @@ const require = createRequire(import.meta.url);
 export async function setupFrameworkPlugin({
   rootDirPath,
   frameworkPlugins,
+  reader,
   logger,
 }: {
   rootDirPath: string;
   frameworkPlugins: FrameworkPluginFactory[];
+  reader: Reader;
   logger: Logger;
 }) {
   const dependencies = await extractPackageDependencies(logger, rootDirPath);
@@ -21,8 +24,9 @@ export async function setupFrameworkPlugin({
     if (await candidate.isCompatible(dependencies)) {
       return candidate.create({
         rootDirPath,
-        dependencies,
+        reader,
         logger,
+        dependencies,
       });
     }
   }

--- a/framework-plugins/preact/src/analyze-component.spec.ts
+++ b/framework-plugins/preact/src/analyze-component.spec.ts
@@ -28,7 +28,7 @@ const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 const ROOT_DIR_PATH = path.join(__dirname, "virtual");
 const MAIN_FILE = path.join(ROOT_DIR_PATH, "App.tsx");
 
-describe.concurrent("analyzePreactComponent", () => {
+describe("analyzePreactComponent", () => {
   let memoryReader: Reader & Writer;
   let typeAnalyzer: TypeAnalyzer;
   let frameworkPlugin: FrameworkPlugin;

--- a/framework-plugins/preact/src/analyze-component.spec.ts
+++ b/framework-plugins/preact/src/analyze-component.spec.ts
@@ -2,7 +2,6 @@ import { decodeComponentId } from "@previewjs/api";
 import type { FrameworkPlugin } from "@previewjs/core";
 import {
   arrayType,
-  createTypeAnalyzer,
   EMPTY_OBJECT_TYPE,
   namedType,
   NODE_TYPE,
@@ -24,7 +23,6 @@ import prettyLogger from "pino-pretty";
 import url from "url";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import preactFrameworkPlugin from ".";
-import { PREACT_SPECIAL_TYPES } from "./special-types.js";
 
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 const ROOT_DIR_PATH = path.join(__dirname, "virtual");
@@ -40,22 +38,18 @@ describe.concurrent("analyzePreactComponent", () => {
     frameworkPlugin = await preactFrameworkPlugin.create({
       rootDirPath: ROOT_DIR_PATH,
       dependencies: {},
-      logger: createLogger(
-        { level: "debug" },
-        prettyLogger({ colorize: true })
-      ),
-    });
-    typeAnalyzer = createTypeAnalyzer({
-      rootDirPath: ROOT_DIR_PATH,
       reader: createStackedReader([
         memoryReader,
         createFileSystemReader({
           watch: false,
         }), // required for TypeScript libs, e.g. Promise
       ]),
-      tsCompilerOptions: frameworkPlugin.tsCompilerOptions,
-      specialTypes: PREACT_SPECIAL_TYPES,
+      logger: createLogger(
+        { level: "debug" },
+        prettyLogger({ colorize: true })
+      ),
     });
+    typeAnalyzer = frameworkPlugin.typeAnalyzer;
   });
 
   afterEach(() => {
@@ -343,9 +337,7 @@ export const A: FunctionComponent<{ foo: string }> = (props) => {
   async function analyze(source: string, componentName: string) {
     memoryReader.updateFile(MAIN_FILE, source);
     const component = (
-      await frameworkPlugin.detectComponents(memoryReader, typeAnalyzer, [
-        MAIN_FILE,
-      ])
+      await frameworkPlugin.detectComponents([MAIN_FILE])
     ).find((c) => decodeComponentId(c.componentId).name === componentName);
     if (!component) {
       throw new Error(`Component ${componentName} not found`);

--- a/framework-plugins/preact/src/extract-component.spec.ts
+++ b/framework-plugins/preact/src/extract-component.spec.ts
@@ -23,7 +23,7 @@ const ROOT_DIR = path.join(__dirname, "virtual");
 const APP_TSX = path.join(ROOT_DIR, "App.tsx");
 const APP_STORIES_TSX = path.join(ROOT_DIR, "App.stories.tsx");
 
-describe.concurrent("extractPreactComponents", () => {
+describe("extractPreactComponents", () => {
   const logger = createLogger(
     { level: "debug" },
     prettyLogger({ colorize: true })

--- a/framework-plugins/preact/src/extract-component.spec.ts
+++ b/framework-plugins/preact/src/extract-component.spec.ts
@@ -1,6 +1,5 @@
 import { object, string, TRUE } from "@previewjs/serializable-values";
 import {
-  createTypeAnalyzer,
   objectType,
   STRING_TYPE,
   TypeAnalyzer,
@@ -42,18 +41,15 @@ describe.concurrent("extractPreactComponents", () => {
     const frameworkPlugin = await reactFrameworkPlugin.create({
       rootDirPath: ROOT_DIR,
       dependencies: {},
-      logger,
-    });
-    typeAnalyzer = createTypeAnalyzer({
-      rootDirPath: ROOT_DIR,
       reader: createStackedReader([
         memoryReader,
         createFileSystemReader({
           watch: false,
         }), // required for TypeScript libs, e.g. Promise
       ]),
-      tsCompilerOptions: frameworkPlugin.tsCompilerOptions,
+      logger,
     });
+    typeAnalyzer = frameworkPlugin.typeAnalyzer;
   });
 
   afterEach(() => {

--- a/framework-plugins/preact/src/index.ts
+++ b/framework-plugins/preact/src/index.ts
@@ -2,6 +2,7 @@ import type {
   AnalyzableComponent,
   FrameworkPluginFactory,
 } from "@previewjs/core";
+import { createTypeAnalyzer } from "@previewjs/type-analyzer";
 import path from "path";
 import ts from "typescript";
 import url from "url";
@@ -16,14 +17,12 @@ const preactFrameworkPlugin: FrameworkPluginFactory = {
     }
     return parseInt(version) >= 10;
   },
-  async create({ rootDirPath, logger }) {
+  async create({ rootDirPath, reader, logger }) {
     const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
     const previewDirPath = path.resolve(__dirname, "..", "preview");
-    return {
-      pluginApiVersion: 3,
-      name: "@previewjs/plugin-preact",
-      defaultWrapperPath: "__previewjs__/Wrapper.tsx",
-      previewDirPath,
+    const typeAnalyzer = createTypeAnalyzer({
+      rootDirPath,
+      reader,
       specialTypes: PREACT_SPECIAL_TYPES,
       tsCompilerOptions: {
         jsx: ts.JsxEmit.ReactJSX,
@@ -31,7 +30,14 @@ const preactFrameworkPlugin: FrameworkPluginFactory = {
         jsxFactory: "h",
         jsxFragmentFactory: "Fragment",
       },
-      detectComponents: async (reader, typeAnalyzer, absoluteFilePaths) => {
+    });
+    return {
+      pluginApiVersion: 3,
+      name: "@previewjs/plugin-preact",
+      defaultWrapperPath: "__previewjs__/Wrapper.tsx",
+      previewDirPath,
+      typeAnalyzer,
+      detectComponents: async (absoluteFilePaths) => {
         const resolver = typeAnalyzer.analyze(absoluteFilePaths);
         const components: AnalyzableComponent[] = [];
         for (const absoluteFilePath of absoluteFilePaths) {

--- a/framework-plugins/react/src/analyze-component.spec.ts
+++ b/framework-plugins/react/src/analyze-component.spec.ts
@@ -32,7 +32,7 @@ const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 const ROOT_DIR_PATH = path.join(__dirname, "virtual");
 const MAIN_FILE = path.join(ROOT_DIR_PATH, "App.tsx");
 
-describe.concurrent("analyzeReactComponent", () => {
+describe("analyzeReactComponent", () => {
   let memoryReader: Reader & Writer;
   let typeAnalyzer: TypeAnalyzer;
   let frameworkPlugin: FrameworkPlugin;

--- a/framework-plugins/react/src/analyze-component.spec.ts
+++ b/framework-plugins/react/src/analyze-component.spec.ts
@@ -3,7 +3,6 @@ import type { FrameworkPlugin } from "@previewjs/core";
 import {
   ANY_TYPE,
   arrayType,
-  createTypeAnalyzer,
   EMPTY_OBJECT_TYPE,
   functionType,
   namedType,
@@ -28,7 +27,6 @@ import prettyLogger from "pino-pretty";
 import url from "url";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import reactFrameworkPlugin from "./index.js";
-import { REACT_SPECIAL_TYPES } from "./special-types.js";
 
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 const ROOT_DIR_PATH = path.join(__dirname, "virtual");
@@ -44,22 +42,18 @@ describe.concurrent("analyzeReactComponent", () => {
     frameworkPlugin = await reactFrameworkPlugin.create({
       rootDirPath: ROOT_DIR_PATH,
       dependencies: {},
-      logger: createLogger(
-        { level: "debug" },
-        prettyLogger({ colorize: true })
-      ),
-    });
-    typeAnalyzer = createTypeAnalyzer({
-      rootDirPath: ROOT_DIR_PATH,
       reader: createStackedReader([
         memoryReader,
         createFileSystemReader({
           watch: false,
         }), // required for TypeScript libs, e.g. Promise
       ]),
-      tsCompilerOptions: frameworkPlugin.tsCompilerOptions,
-      specialTypes: REACT_SPECIAL_TYPES,
+      logger: createLogger(
+        { level: "debug" },
+        prettyLogger({ colorize: true })
+      ),
     });
+    typeAnalyzer = frameworkPlugin.typeAnalyzer;
   });
 
   afterEach(() => {
@@ -557,9 +551,7 @@ A.propTypes = {
   async function analyze(source: string, componentName: string) {
     memoryReader.updateFile(MAIN_FILE, source);
     const component = (
-      await frameworkPlugin.detectComponents(memoryReader, typeAnalyzer, [
-        MAIN_FILE,
-      ])
+      await frameworkPlugin.detectComponents([MAIN_FILE])
     ).find((c) => decodeComponentId(c.componentId).name === componentName);
     if (!component) {
       throw new Error(`Component ${componentName} not found`);

--- a/framework-plugins/react/src/extract-component.spec.ts
+++ b/framework-plugins/react/src/extract-component.spec.ts
@@ -23,7 +23,7 @@ const ROOT_DIR = path.join(__dirname, "virtual");
 const APP_TSX = path.join(ROOT_DIR, "App.tsx");
 const APP_STORIES_TSX = path.join(ROOT_DIR, "App.stories.tsx");
 
-describe.concurrent("extractReactComponents", () => {
+describe("extractReactComponents", () => {
   const logger = createLogger(
     { level: "debug" },
     prettyLogger({ colorize: true })

--- a/framework-plugins/react/src/extract-component.spec.ts
+++ b/framework-plugins/react/src/extract-component.spec.ts
@@ -1,6 +1,5 @@
 import { object, string, TRUE } from "@previewjs/serializable-values";
 import {
-  createTypeAnalyzer,
   objectType,
   STRING_TYPE,
   TypeAnalyzer,
@@ -42,18 +41,15 @@ describe.concurrent("extractReactComponents", () => {
     const frameworkPlugin = await reactFrameworkPlugin.create({
       rootDirPath: ROOT_DIR,
       dependencies: {},
-      logger,
-    });
-    typeAnalyzer = createTypeAnalyzer({
-      rootDirPath: ROOT_DIR,
       reader: createStackedReader([
         memoryReader,
         createFileSystemReader({
           watch: false,
         }), // required for TypeScript libs, e.g. Promise
       ]),
-      tsCompilerOptions: frameworkPlugin.tsCompilerOptions,
+      logger,
     });
+    typeAnalyzer = frameworkPlugin.typeAnalyzer;
   });
 
   afterEach(() => {

--- a/framework-plugins/react/src/index.ts
+++ b/framework-plugins/react/src/index.ts
@@ -32,7 +32,16 @@ const reactFrameworkPlugin: FrameworkPluginFactory = {
     const previewDirPath = path.join(__dirname, "..", "preview");
     const typeAnalyzer = createTypeAnalyzer({
       rootDirPath,
-      reader,
+      reader: createStackedReader([
+        reader,
+        createFileSystemReader({
+          mapping: {
+            from: path.join(previewDirPath, "types"),
+            to: path.join(rootDirPath, "node_modules", "@types"),
+          },
+          watch: false,
+        }),
+      ]),
       specialTypes: REACT_SPECIAL_TYPES,
       tsCompilerOptions: {
         jsx: ts.JsxEmit.ReactJSX,
@@ -45,17 +54,6 @@ const reactFrameworkPlugin: FrameworkPluginFactory = {
       defaultWrapperPath: "__previewjs__/Wrapper.tsx",
       previewDirPath,
       typeAnalyzer,
-      transformReader: (reader) =>
-        createStackedReader([
-          reader,
-          createFileSystemReader({
-            mapping: {
-              from: path.join(previewDirPath, "types"),
-              to: path.join(rootDirPath, "node_modules", "@types"),
-            },
-            watch: false,
-          }),
-        ]),
       detectComponents: async (absoluteFilePaths) => {
         const resolver = typeAnalyzer.analyze(absoluteFilePaths);
         const components: AnalyzableComponent[] = [];

--- a/framework-plugins/solid/src/analyze-component.spec.ts
+++ b/framework-plugins/solid/src/analyze-component.spec.ts
@@ -2,7 +2,6 @@ import { decodeComponentId } from "@previewjs/api";
 import type { FrameworkPlugin } from "@previewjs/core";
 import {
   arrayType,
-  createTypeAnalyzer,
   EMPTY_OBJECT_TYPE,
   namedType,
   NODE_TYPE,
@@ -22,7 +21,6 @@ import createLogger from "pino";
 import prettyLogger from "pino-pretty";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import solidFrameworkPlugin from ".";
-import { SOLID_SPECIAL_TYPES } from "./special-types.js";
 
 const ROOT_DIR_PATH = path.join(__dirname, "virtual");
 const MAIN_FILE = path.join(ROOT_DIR_PATH, "App.tsx");
@@ -37,22 +35,18 @@ describe.concurrent("analyzeSolidComponent", () => {
     frameworkPlugin = await solidFrameworkPlugin.create({
       rootDirPath: ROOT_DIR_PATH,
       dependencies: {},
-      logger: createLogger(
-        { level: "debug" },
-        prettyLogger({ colorize: true })
-      ),
-    });
-    typeAnalyzer = createTypeAnalyzer({
-      rootDirPath: ROOT_DIR_PATH,
       reader: createStackedReader([
         memoryReader,
         createFileSystemReader({
           watch: false,
         }), // required for TypeScript libs, e.g. Promise
       ]),
-      tsCompilerOptions: frameworkPlugin.tsCompilerOptions,
-      specialTypes: SOLID_SPECIAL_TYPES,
+      logger: createLogger(
+        { level: "debug" },
+        prettyLogger({ colorize: true })
+      ),
     });
+    typeAnalyzer = frameworkPlugin.typeAnalyzer;
   });
 
   afterEach(() => {
@@ -360,9 +354,7 @@ A.args = {
   async function analyze(source: string, componentName: string) {
     memoryReader.updateFile(MAIN_FILE, source);
     const component = (
-      await frameworkPlugin.detectComponents(memoryReader, typeAnalyzer, [
-        MAIN_FILE,
-      ])
+      await frameworkPlugin.detectComponents([MAIN_FILE])
     ).find((c) => decodeComponentId(c.componentId).name === componentName);
     if (!component) {
       throw new Error(`Component ${componentName} not found`);

--- a/framework-plugins/solid/src/analyze-component.spec.ts
+++ b/framework-plugins/solid/src/analyze-component.spec.ts
@@ -25,7 +25,7 @@ import solidFrameworkPlugin from ".";
 const ROOT_DIR_PATH = path.join(__dirname, "virtual");
 const MAIN_FILE = path.join(ROOT_DIR_PATH, "App.tsx");
 
-describe.concurrent("analyzeSolidComponent", () => {
+describe("analyzeSolidComponent", () => {
   let memoryReader: Reader & Writer;
   let typeAnalyzer: TypeAnalyzer;
   let frameworkPlugin: FrameworkPlugin;

--- a/framework-plugins/solid/src/extract-component.spec.ts
+++ b/framework-plugins/solid/src/extract-component.spec.ts
@@ -21,7 +21,7 @@ const ROOT_DIR = path.join(__dirname, "virtual");
 const APP_TSX = path.join(ROOT_DIR, "App.tsx");
 const APP_STORIES_TSX = path.join(ROOT_DIR, "App.stories.tsx");
 
-describe.concurrent("extractSolidComponents", () => {
+describe("extractSolidComponents", () => {
   const logger = createLogger(
     { level: "debug" },
     prettyLogger({ colorize: true })

--- a/framework-plugins/solid/src/extract-component.spec.ts
+++ b/framework-plugins/solid/src/extract-component.spec.ts
@@ -1,6 +1,5 @@
 import { object, string, TRUE } from "@previewjs/serializable-values";
 import {
-  createTypeAnalyzer,
   objectType,
   STRING_TYPE,
   TypeAnalyzer,
@@ -40,18 +39,15 @@ describe.concurrent("extractSolidComponents", () => {
     const frameworkPlugin = await solidFrameworkPlugin.create({
       rootDirPath: ROOT_DIR,
       dependencies: {},
-      logger,
-    });
-    typeAnalyzer = createTypeAnalyzer({
-      rootDirPath: ROOT_DIR,
       reader: createStackedReader([
         memoryReader,
         createFileSystemReader({
           watch: false,
         }), // required for TypeScript libs, e.g. Promise
       ]),
-      tsCompilerOptions: frameworkPlugin.tsCompilerOptions,
+      logger,
     });
+    typeAnalyzer = frameworkPlugin.typeAnalyzer;
   });
 
   afterEach(() => {

--- a/framework-plugins/solid/src/index.ts
+++ b/framework-plugins/solid/src/index.ts
@@ -2,6 +2,7 @@ import type {
   AnalyzableComponent,
   FrameworkPluginFactory,
 } from "@previewjs/core";
+import { createTypeAnalyzer } from "@previewjs/type-analyzer";
 import path from "path";
 import ts from "typescript";
 import url from "url";
@@ -18,20 +19,25 @@ const solidFrameworkPlugin: FrameworkPluginFactory = {
     }
     return parseInt(version) === 1;
   },
-  async create({ rootDirPath, logger }) {
+  async create({ rootDirPath, reader, logger }) {
     const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
     const previewDirPath = path.resolve(__dirname, "..", "preview");
-    return {
-      pluginApiVersion: 3,
-      name: "@previewjs/plugin-solid",
-      defaultWrapperPath: "__previewjs__/Wrapper.tsx",
-      previewDirPath,
+    const typeAnalyzer = createTypeAnalyzer({
+      rootDirPath,
+      reader,
       specialTypes: SOLID_SPECIAL_TYPES,
       tsCompilerOptions: {
         jsx: ts.JsxEmit.Preserve,
         jsxImportSource: "solid-js",
       },
-      detectComponents: async (reader, typeAnalyzer, absoluteFilePaths) => {
+    });
+    return {
+      pluginApiVersion: 3,
+      name: "@previewjs/plugin-solid",
+      defaultWrapperPath: "__previewjs__/Wrapper.tsx",
+      previewDirPath,
+      typeAnalyzer,
+      detectComponents: async (absoluteFilePaths) => {
         const resolver = typeAnalyzer.analyze(absoluteFilePaths);
         const components: AnalyzableComponent[] = [];
         for (const absoluteFilePath of absoluteFilePaths) {

--- a/framework-plugins/svelte/src/analyze-component.spec.ts
+++ b/framework-plugins/svelte/src/analyze-component.spec.ts
@@ -19,7 +19,6 @@ import prettyLogger from "pino-pretty";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import svelteFrameworkPlugin from ".";
 import { inferComponentNameFromSveltePath } from "./infer-component-name";
-import { createSvelteTypeScriptReader } from "./svelte-reader";
 
 const ROOT_DIR_PATH = path.join(__dirname, "virtual");
 const MAIN_FILE = path.join(ROOT_DIR_PATH, "App.svelte");
@@ -34,21 +33,19 @@ describe.concurrent("analyze Svelte component", () => {
     frameworkPlugin = await svelteFrameworkPlugin.create({
       rootDirPath: ROOT_DIR_PATH,
       dependencies: {},
-      reader: createSvelteTypeScriptReader(
-        createStackedReader([
-          memoryReader,
-          createFileSystemReader({
-            watch: false,
-          }), // required for TypeScript libs, e.g. Promise
-          createFileSystemReader({
-            mapping: {
-              from: path.join(__dirname, "..", "preview", "modules"),
-              to: path.join(ROOT_DIR_PATH, "node_modules"),
-            },
-            watch: false,
-          }),
-        ])
-      ),
+      reader: createStackedReader([
+        memoryReader,
+        createFileSystemReader({
+          watch: false,
+        }), // required for TypeScript libs, e.g. Promise
+        createFileSystemReader({
+          mapping: {
+            from: path.join(__dirname, "..", "preview", "modules"),
+            to: path.join(ROOT_DIR_PATH, "node_modules"),
+          },
+          watch: false,
+        }),
+      ]),
       logger: createLogger(
         { level: "debug" },
         prettyLogger({ colorize: true })

--- a/framework-plugins/svelte/src/analyze-component.spec.ts
+++ b/framework-plugins/svelte/src/analyze-component.spec.ts
@@ -23,7 +23,7 @@ import { inferComponentNameFromSveltePath } from "./infer-component-name";
 const ROOT_DIR_PATH = path.join(__dirname, "virtual");
 const MAIN_FILE = path.join(ROOT_DIR_PATH, "App.svelte");
 
-describe.concurrent("analyze Svelte component", () => {
+describe("analyze Svelte component", () => {
   let memoryReader: Reader & Writer;
   let typeAnalyzer: TypeAnalyzer;
   let frameworkPlugin: FrameworkPlugin;

--- a/framework-plugins/svelte/src/analyze-component.spec.ts
+++ b/framework-plugins/svelte/src/analyze-component.spec.ts
@@ -2,7 +2,6 @@ import { decodeComponentId } from "@previewjs/api";
 import type { FrameworkPlugin } from "@previewjs/core";
 import {
   ANY_TYPE,
-  createTypeAnalyzer,
   NUMBER_TYPE,
   objectType,
   optionalType,
@@ -35,13 +34,6 @@ describe.concurrent("analyze Svelte component", () => {
     frameworkPlugin = await svelteFrameworkPlugin.create({
       rootDirPath: ROOT_DIR_PATH,
       dependencies: {},
-      logger: createLogger(
-        { level: "debug" },
-        prettyLogger({ colorize: true })
-      ),
-    });
-    typeAnalyzer = createTypeAnalyzer({
-      rootDirPath: ROOT_DIR_PATH,
       reader: createSvelteTypeScriptReader(
         createStackedReader([
           memoryReader,
@@ -57,8 +49,12 @@ describe.concurrent("analyze Svelte component", () => {
           }),
         ])
       ),
-      tsCompilerOptions: frameworkPlugin.tsCompilerOptions,
+      logger: createLogger(
+        { level: "debug" },
+        prettyLogger({ colorize: true })
+      ),
     });
+    typeAnalyzer = frameworkPlugin.typeAnalyzer;
   });
 
   afterEach(() => {
@@ -184,9 +180,7 @@ describe.concurrent("analyze Svelte component", () => {
     memoryReader.updateFile(MAIN_FILE, source);
     const componentName = inferComponentNameFromSveltePath(MAIN_FILE);
     const component = (
-      await frameworkPlugin.detectComponents(memoryReader, typeAnalyzer, [
-        MAIN_FILE,
-      ])
+      await frameworkPlugin.detectComponents([MAIN_FILE])
     ).find((c) => decodeComponentId(c.componentId).name === componentName);
     if (!component) {
       throw new Error(`Component ${componentName} not found`);

--- a/framework-plugins/svelte/src/svelte-reader.spec.ts
+++ b/framework-plugins/svelte/src/svelte-reader.spec.ts
@@ -9,7 +9,7 @@ import path from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createSvelteTypeScriptReader } from "./svelte-reader";
 
-describe.concurrent("createSvelteTypeScriptReader", () => {
+describe("createSvelteTypeScriptReader", () => {
   let memoryReader: Reader & Writer;
   let reader: Reader;
   let typeAnalyzer: TypeAnalyzer;

--- a/framework-plugins/vue2/src/analyze-component.spec.ts
+++ b/framework-plugins/vue2/src/analyze-component.spec.ts
@@ -26,7 +26,7 @@ import { inferComponentNameFromVuePath } from "./infer-component-name.js";
 const ROOT_DIR_PATH = path.join(__dirname, "virtual");
 const MAIN_FILE = path.join(ROOT_DIR_PATH, "App.vue");
 
-describe.concurrent("analyze Vue 2 component", () => {
+describe("analyze Vue 2 component", () => {
   const logger = createLogger(
     { level: "debug" },
     prettyLogger({ colorize: true })

--- a/framework-plugins/vue2/src/analyze-component.spec.ts
+++ b/framework-plugins/vue2/src/analyze-component.spec.ts
@@ -1,7 +1,6 @@
 import { decodeComponentId } from "@previewjs/api";
 import type { FrameworkPlugin } from "@previewjs/core";
 import {
-  createTypeAnalyzer,
   literalType,
   NUMBER_TYPE,
   objectType,
@@ -43,10 +42,6 @@ describe.concurrent("analyze Vue 2 component", () => {
     frameworkPlugin = await vue2FrameworkPlugin.create({
       rootDirPath: ROOT_DIR_PATH,
       dependencies: {},
-      logger,
-    });
-    typeAnalyzer = createTypeAnalyzer({
-      rootDirPath: ROOT_DIR_PATH,
       reader: createVueTypeScriptReader(
         logger,
         createStackedReader([
@@ -63,8 +58,9 @@ describe.concurrent("analyze Vue 2 component", () => {
           }),
         ])
       ),
-      tsCompilerOptions: frameworkPlugin.tsCompilerOptions,
+      logger,
     });
+    typeAnalyzer = frameworkPlugin.typeAnalyzer;
   });
 
   afterEach(() => {
@@ -198,9 +194,7 @@ export default class App extends Vue {
     memoryReader.updateFile(MAIN_FILE, source);
     const componentName = inferComponentNameFromVuePath(MAIN_FILE);
     const component = (
-      await frameworkPlugin.detectComponents(memoryReader, typeAnalyzer, [
-        MAIN_FILE,
-      ])
+      await frameworkPlugin.detectComponents([MAIN_FILE])
     ).find((c) => decodeComponentId(c.componentId).name === componentName);
     if (!component) {
       throw new Error(`Component ${componentName} not found`);

--- a/framework-plugins/vue2/src/analyze-component.spec.ts
+++ b/framework-plugins/vue2/src/analyze-component.spec.ts
@@ -22,7 +22,6 @@ import prettyLogger from "pino-pretty";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import vue2FrameworkPlugin from ".";
 import { inferComponentNameFromVuePath } from "./infer-component-name.js";
-import { createVueTypeScriptReader } from "./vue-reader.js";
 
 const ROOT_DIR_PATH = path.join(__dirname, "virtual");
 const MAIN_FILE = path.join(ROOT_DIR_PATH, "App.vue");
@@ -42,22 +41,19 @@ describe.concurrent("analyze Vue 2 component", () => {
     frameworkPlugin = await vue2FrameworkPlugin.create({
       rootDirPath: ROOT_DIR_PATH,
       dependencies: {},
-      reader: createVueTypeScriptReader(
-        logger,
-        createStackedReader([
-          memoryReader,
-          createFileSystemReader({
-            watch: false,
-          }), // required for TypeScript libs, e.g. Promise
-          createFileSystemReader({
-            mapping: {
-              from: path.join(__dirname, "..", "preview", "modules"),
-              to: path.join(ROOT_DIR_PATH, "node_modules"),
-            },
-            watch: false,
-          }),
-        ])
-      ),
+      reader: createStackedReader([
+        memoryReader,
+        createFileSystemReader({
+          watch: false,
+        }), // required for TypeScript libs, e.g. Promise
+        createFileSystemReader({
+          mapping: {
+            from: path.join(__dirname, "..", "preview", "modules"),
+            to: path.join(ROOT_DIR_PATH, "node_modules"),
+          },
+          watch: false,
+        }),
+      ]),
       logger,
     });
     typeAnalyzer = frameworkPlugin.typeAnalyzer;

--- a/framework-plugins/vue2/src/extract-component.spec.ts
+++ b/framework-plugins/vue2/src/extract-component.spec.ts
@@ -23,7 +23,7 @@ const APP_TSX = path.join(ROOT_DIR, "App.tsx");
 const MY_COMPONENT_VUE = path.join(ROOT_DIR, "MyComponent.vue");
 const APP_STORIES_TSX = path.join(ROOT_DIR, "App.stories.tsx");
 
-describe.concurrent("extractVueComponents", () => {
+describe("extractVueComponents", () => {
   const logger = createLogger(
     { level: "debug" },
     prettyLogger({ colorize: true })

--- a/framework-plugins/vue2/src/extract-component.spec.ts
+++ b/framework-plugins/vue2/src/extract-component.spec.ts
@@ -1,6 +1,5 @@
 import { object, string, TRUE } from "@previewjs/serializable-values";
 import {
-  createTypeAnalyzer,
   objectType,
   STRING_TYPE,
   TypeAnalyzer,
@@ -58,11 +57,6 @@ export default {
 `
     );
     const rootDirPath = path.join(__dirname, "virtual");
-    const frameworkPlugin = await vue2FrameworkPlugin.create({
-      rootDirPath,
-      dependencies: {},
-      logger,
-    });
     const reader = createStackedReader([
       createVueTypeScriptReader(logger, memoryReader),
       createFileSystemReader({
@@ -76,11 +70,13 @@ export default {
         watch: false,
       }), // required for TypeScript libs, e.g. Promise
     ]);
-    typeAnalyzer = createTypeAnalyzer({
+    const frameworkPlugin = await vue2FrameworkPlugin.create({
       rootDirPath,
+      dependencies: {},
       reader,
-      tsCompilerOptions: frameworkPlugin.tsCompilerOptions,
+      logger,
     });
+    typeAnalyzer = frameworkPlugin.typeAnalyzer;
   });
 
   afterEach(() => {

--- a/framework-plugins/vue2/src/vue-reader.spec.ts
+++ b/framework-plugins/vue2/src/vue-reader.spec.ts
@@ -6,7 +6,7 @@ import prettyLogger from "pino-pretty";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createVueTypeScriptReader } from "./vue-reader";
 
-describe.concurrent("createVueTypeScriptReader", () => {
+describe("createVueTypeScriptReader", () => {
   let memoryReader: Reader & Writer;
   let reader: Reader;
 

--- a/framework-plugins/vue3/src/analyze-component.spec.ts
+++ b/framework-plugins/vue3/src/analyze-component.spec.ts
@@ -23,7 +23,7 @@ import { inferComponentNameFromVuePath } from "./infer-component-name.js";
 const ROOT_DIR_PATH = path.join(__dirname, "virtual");
 const MAIN_FILE = path.join(ROOT_DIR_PATH, "App.vue");
 
-describe.concurrent("analyze Vue 3 component", () => {
+describe("analyze Vue 3 component", () => {
   let memoryReader: Reader & Writer;
   let typeAnalyzer: TypeAnalyzer;
   let frameworkPlugin: FrameworkPlugin;

--- a/framework-plugins/vue3/src/analyze-component.spec.ts
+++ b/framework-plugins/vue3/src/analyze-component.spec.ts
@@ -2,7 +2,6 @@ import { decodeComponentId } from "@previewjs/api";
 import type { FrameworkPlugin } from "@previewjs/core";
 import {
   BOOLEAN_TYPE,
-  createTypeAnalyzer,
   objectType,
   optionalType,
   STRING_TYPE,
@@ -35,13 +34,6 @@ describe.concurrent("analyze Vue 3 component", () => {
     frameworkPlugin = await vue3FrameworkPlugin.create({
       rootDirPath: ROOT_DIR_PATH,
       dependencies: {},
-      logger: createLogger(
-        { level: "debug" },
-        prettyLogger({ colorize: true })
-      ),
-    });
-    typeAnalyzer = createTypeAnalyzer({
-      rootDirPath: ROOT_DIR_PATH,
       reader: createVueTypeScriptReader(
         createStackedReader([
           memoryReader,
@@ -57,8 +49,12 @@ describe.concurrent("analyze Vue 3 component", () => {
           }),
         ])
       ),
-      tsCompilerOptions: frameworkPlugin.tsCompilerOptions,
+      logger: createLogger(
+        { level: "debug" },
+        prettyLogger({ colorize: true })
+      ),
     });
+    typeAnalyzer = frameworkPlugin.typeAnalyzer;
   });
 
   afterEach(() => {
@@ -314,9 +310,7 @@ export default defineComponent({
     memoryReader.updateFile(MAIN_FILE, source);
     const componentName = inferComponentNameFromVuePath(MAIN_FILE);
     const component = (
-      await frameworkPlugin.detectComponents(memoryReader, typeAnalyzer, [
-        MAIN_FILE,
-      ])
+      await frameworkPlugin.detectComponents([MAIN_FILE])
     ).find((c) => decodeComponentId(c.componentId).name === componentName);
     if (!component) {
       throw new Error(`Component ${componentName} not found`);

--- a/framework-plugins/vue3/src/analyze-component.spec.ts
+++ b/framework-plugins/vue3/src/analyze-component.spec.ts
@@ -19,7 +19,6 @@ import prettyLogger from "pino-pretty";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import vue3FrameworkPlugin from ".";
 import { inferComponentNameFromVuePath } from "./infer-component-name.js";
-import { createVueTypeScriptReader } from "./vue-reader.js";
 
 const ROOT_DIR_PATH = path.join(__dirname, "virtual");
 const MAIN_FILE = path.join(ROOT_DIR_PATH, "App.vue");
@@ -34,21 +33,19 @@ describe.concurrent("analyze Vue 3 component", () => {
     frameworkPlugin = await vue3FrameworkPlugin.create({
       rootDirPath: ROOT_DIR_PATH,
       dependencies: {},
-      reader: createVueTypeScriptReader(
-        createStackedReader([
-          memoryReader,
-          createFileSystemReader({
-            watch: false,
-          }), // required for TypeScript libs, e.g. Promise
-          createFileSystemReader({
-            mapping: {
-              from: path.join(__dirname, "..", "preview", "modules"),
-              to: path.join(ROOT_DIR_PATH, "node_modules"),
-            },
-            watch: false,
-          }),
-        ])
-      ),
+      reader: createStackedReader([
+        memoryReader,
+        createFileSystemReader({
+          watch: false,
+        }), // required for TypeScript libs, e.g. Promise
+        createFileSystemReader({
+          mapping: {
+            from: path.join(__dirname, "..", "preview", "modules"),
+            to: path.join(ROOT_DIR_PATH, "node_modules"),
+          },
+          watch: false,
+        }),
+      ]),
       logger: createLogger(
         { level: "debug" },
         prettyLogger({ colorize: true })

--- a/framework-plugins/vue3/src/extract-component.spec.ts
+++ b/framework-plugins/vue3/src/extract-component.spec.ts
@@ -23,7 +23,7 @@ const APP_TSX = path.join(ROOT_DIR, "App.tsx");
 const MY_COMPONENT_VUE = path.join(ROOT_DIR, "MyComponent.vue");
 const APP_STORIES_TSX = path.join(ROOT_DIR, "App.stories.tsx");
 
-describe.concurrent("extractVueComponents", () => {
+describe("extractVueComponents", () => {
   let memoryReader: Reader & Writer;
   let typeAnalyzer: TypeAnalyzer;
 

--- a/framework-plugins/vue3/src/extract-component.spec.ts
+++ b/framework-plugins/vue3/src/extract-component.spec.ts
@@ -1,6 +1,5 @@
 import { object, string, TRUE } from "@previewjs/serializable-values";
 import {
-  createTypeAnalyzer,
   objectType,
   STRING_TYPE,
   TypeAnalyzer,
@@ -49,14 +48,6 @@ const count = ref(0)
 `
     );
     const rootDirPath = path.join(__dirname, "virtual");
-    const frameworkPlugin = await vue3FrameworkPlugin.create({
-      rootDirPath,
-      dependencies: {},
-      logger: createLogger(
-        { level: "debug" },
-        prettyLogger({ colorize: true })
-      ),
-    });
     const reader = createStackedReader([
       createVueTypeScriptReader(memoryReader),
       createFileSystemReader({
@@ -70,11 +61,16 @@ const count = ref(0)
         watch: false,
       }), // required for TypeScript libs, e.g. Promise
     ]);
-    typeAnalyzer = createTypeAnalyzer({
+    const frameworkPlugin = await vue3FrameworkPlugin.create({
       rootDirPath,
+      dependencies: {},
       reader,
-      tsCompilerOptions: frameworkPlugin.tsCompilerOptions,
+      logger: createLogger(
+        { level: "debug" },
+        prettyLogger({ colorize: true })
+      ),
     });
+    typeAnalyzer = frameworkPlugin.typeAnalyzer;
   });
 
   afterEach(() => {

--- a/framework-plugins/vue3/src/index.ts
+++ b/framework-plugins/vue3/src/index.ts
@@ -2,6 +2,7 @@ import type {
   AnalyzableComponent,
   FrameworkPluginFactory,
 } from "@previewjs/core";
+import { createTypeAnalyzer } from "@previewjs/type-analyzer";
 import { createFileSystemReader, createStackedReader } from "@previewjs/vfs";
 import path from "path";
 import url from "url";
@@ -19,31 +20,34 @@ const vue3FrameworkPlugin: FrameworkPluginFactory = {
     }
     return parseInt(version) === 3;
   },
-  async create({ rootDirPath }) {
+  async create({ rootDirPath, reader }) {
     const { default: createVuePlugin } = await import("@vitejs/plugin-vue");
     const { default: vueJsxPlugin } = await import("@vitejs/plugin-vue-jsx");
     const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
     const previewDirPath = path.resolve(__dirname, "..", "preview");
+    const typeAnalyzer = createTypeAnalyzer({
+      rootDirPath,
+      reader: createStackedReader([
+        createVueTypeScriptReader(reader),
+        createFileSystemReader({
+          mapping: {
+            from: path.join(previewDirPath, "modules"),
+            to: path.join(rootDirPath, "node_modules"),
+          },
+          watch: false,
+        }),
+      ]),
+      tsCompilerOptions: {
+        types: ["vue/jsx"],
+      },
+    });
     return {
       pluginApiVersion: 3,
       name: "@previewjs/plugin-vue3",
       defaultWrapperPath: "__previewjs__/Wrapper.vue",
       previewDirPath,
-      tsCompilerOptions: {
-        types: ["vue/jsx"],
-      },
-      transformReader: (reader) =>
-        createStackedReader([
-          createVueTypeScriptReader(reader),
-          createFileSystemReader({
-            mapping: {
-              from: path.join(previewDirPath, "modules"),
-              to: path.join(rootDirPath, "node_modules"),
-            },
-            watch: false,
-          }),
-        ]),
-      detectComponents: async (reader, typeAnalyzer, absoluteFilePaths) => {
+      typeAnalyzer,
+      detectComponents: async (absoluteFilePaths) => {
         const resolver = typeAnalyzer.analyze(
           absoluteFilePaths.map((p) => (p.endsWith(".vue") ? p + ".ts" : p))
         );

--- a/framework-plugins/vue3/src/vue-reader.spec.ts
+++ b/framework-plugins/vue3/src/vue-reader.spec.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createVueTypeScriptReader } from "./vue-reader";
 
-describe.concurrent("createVueTypeScriptReader", () => {
+describe("createVueTypeScriptReader", () => {
   let memoryReader: Reader & Writer;
   let reader: Reader;
 

--- a/loader/src/runner.ts
+++ b/loader/src/runner.ts
@@ -82,6 +82,7 @@ export async function load({
         const frameworkPlugin = await core.setupFrameworkPlugin({
           rootDirPath,
           frameworkPlugins,
+          reader,
           logger,
         });
         if (!frameworkPlugin) {

--- a/serializable-values/src/parser.spec.ts
+++ b/serializable-values/src/parser.spec.ts
@@ -26,7 +26,7 @@ import {
 } from "./serializable-value";
 import { serializableValueToJavaScript } from "./serializable-value-to-js";
 
-describe.concurrent("parseSerializableValue", () => {
+describe("parseSerializableValue", () => {
   it("parses null", () => {
     expectParsedExpression(`null`).toEqual<SerializableValue>(NULL);
   });

--- a/storybook-helpers/src/extract-args.spec.ts
+++ b/storybook-helpers/src/extract-args.spec.ts
@@ -6,23 +6,23 @@ import {
   string,
   unknown,
 } from "@previewjs/serializable-values";
+import type { TypeAnalyzer } from "@previewjs/type-analyzer";
 import {
+  NODE_TYPE,
   createTypeAnalyzer,
   functionType,
-  NODE_TYPE,
 } from "@previewjs/type-analyzer";
+import type { Reader, Writer } from "@previewjs/vfs";
 import {
   createFileSystemReader,
   createMemoryReader,
   createStackedReader,
 } from "@previewjs/vfs";
-import type { TypeAnalyzer } from "@previewjs/type-analyzer";
-import type { Reader, Writer } from "@previewjs/vfs";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { extractArgs } from "./extract-args";
 
-describe.concurrent("extractArgs", () => {
+describe("extractArgs", () => {
   let memoryReader: Reader & Writer;
   let typeAnalyzer: TypeAnalyzer;
 

--- a/storybook-helpers/src/extract-csf3-stories.spec.ts
+++ b/storybook-helpers/src/extract-csf3-stories.spec.ts
@@ -15,7 +15,7 @@ const ROOT_DIR = path.join(__dirname, "virtual");
 const APP_TSX = path.join(ROOT_DIR, "App.tsx");
 const APP_STORIES_JSX = path.join(ROOT_DIR, "App.stories.jsx");
 
-describe.concurrent("extractCsf3Stories", () => {
+describe("extractCsf3Stories", () => {
   let memoryReader: Reader & Writer;
   let typeAnalyzer: TypeAnalyzer;
 

--- a/type-analyzer/src/analyzer.spec.ts
+++ b/type-analyzer/src/analyzer.spec.ts
@@ -34,7 +34,7 @@ import {
   unionType,
 } from ".";
 
-describe.concurrent("TypeAnalyzer", () => {
+describe("TypeAnalyzer", () => {
   let memoryReader: Reader & Writer;
   let typeAnalyzer: TypeAnalyzer;
 

--- a/type-analyzer/src/analyzer.ts
+++ b/type-analyzer/src/analyzer.ts
@@ -79,6 +79,14 @@ class TypeAnalyzer {
     );
   }
 
+  invalidateCachedTypesForFile(filePath: string) {
+    for (const name of Object.keys(this.collected)) {
+      if (name.startsWith(`${filePath}:`)) {
+        delete this.collected[name];
+      }
+    }
+  }
+
   analyze(filePaths: string[]) {
     if (!this.service) {
       throw new Error(`TypeAnalyzer already disposed of`);

--- a/vfs/src/memory.spec.ts
+++ b/vfs/src/memory.spec.ts
@@ -2,7 +2,7 @@ import path from "path";
 import { describe, expect, it } from "vitest";
 import { MemoryReader } from "./memory";
 
-describe.concurrent("MemoryReader", () => {
+describe("MemoryReader", () => {
   it("reads null when empty", async () => {
     const memoryReader = new MemoryReader();
     expect(await memoryReader.read(path.join(__dirname, "foo"))).toBe(null);

--- a/vfs/src/stacked.spec.ts
+++ b/vfs/src/stacked.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { MemoryReader } from "./memory";
 import { StackedReader } from "./stacked";
 
-describe.concurrent("StackedReader", () => {
+describe("StackedReader", () => {
   it("merges directories recursively (async)", async () => {
     const reader1 = new MemoryReader();
     const reader2 = new MemoryReader();


### PR DESCRIPTION
This also removes `describe.concurrent` usage because it turns out that causes tests to share top-level variables.