### PR TITLE
refactor: remove union discriminator between Component and Story

### DIFF
--- a/api/src/rpcs.ts
+++ b/api/src/rpcs.ts
@@ -37,7 +37,6 @@ export type Component = {
   componentId: string;
   start: number;
   end: number;
-  kind: "component";
   exported: boolean;
 };
 
@@ -45,7 +44,6 @@ export type Story = {
   componentId: string;
   start: number;
   end: number;
-  kind: "story";
   args: {
     start: number;
     end: number;

--- a/chromeless/src/preview.ts
+++ b/chromeless/src/preview.ts
@@ -128,10 +128,13 @@ export async function startPreview({
       const { components, stories } = await workspace.detectComponents({
         filePaths: [filePath],
       });
-      const matchingDetectedComponent =
-        components.find((c) => componentId === c.componentId) ||
-        stories.find((c) => componentId === c.componentId);
-      if (!matchingDetectedComponent) {
+      const matchingDetectedComponent = components.find(
+        (c) => componentId === c.componentId
+      );
+      const matchingDetectedStory = stories.find(
+        (c) => componentId === c.componentId
+      );
+      if (!matchingDetectedComponent && !matchingDetectedStory) {
         throw new Error(
           `Component may be previewable but was not detected by framework plugin: ${componentId}`
         );
@@ -145,14 +148,13 @@ export async function startPreview({
         computePropsResponse.types
       );
       if (!propsAssignmentSource) {
-        propsAssignmentSource =
-          matchingDetectedComponent.kind === "story"
-            ? "properties = null"
-            : await generatePropsAssignmentSource(
-                props,
-                autogenCallbackProps.keys,
-                computePropsResponse.types
-              );
+        propsAssignmentSource = matchingDetectedStory
+          ? "properties = null"
+          : await generatePropsAssignmentSource(
+              props,
+              autogenCallbackProps.keys,
+              computePropsResponse.types
+            );
       }
       const donePromise = new Promise<void>((resolve, reject) => {
         onRenderingDone = resolve;

--- a/component-analyzer/api/src/api.ts
+++ b/component-analyzer/api/src/api.ts
@@ -28,7 +28,6 @@ export interface BaseComponent {
 }
 
 export interface Component extends BaseComponent {
-  kind: "component";
   exported: boolean;
   extractProps: () => Promise<ComponentProps>;
 }
@@ -39,7 +38,6 @@ export interface ComponentProps {
 }
 
 export interface Story extends BaseComponent {
-  kind: "story";
   args: {
     start: number;
     end: number;

--- a/component-analyzer/react/src/extract-component.spec.ts
+++ b/component-analyzer/react/src/extract-component.spec.ts
@@ -110,12 +110,10 @@ export const AlsoNotAStory = {
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:DeclaredFunction",
-        kind: "component",
         exported: false,
       },
       {
         componentId: "App.tsx:ConstantFunction",
-        kind: "component",
         exported: false,
       },
       // Note: this isn't detected as of October 2021.
@@ -126,37 +124,30 @@ export const AlsoNotAStory = {
       // },
       {
         componentId: "App.tsx:ClassComponent1",
-        kind: "component",
         exported: false,
       },
       {
         componentId: "App.tsx:ClassComponent2",
-        kind: "component",
         exported: false,
       },
       {
         componentId: "App.tsx:ForwardRef",
-        kind: "component",
         exported: false,
       },
       {
         componentId: "App.tsx:NextComponent",
-        kind: "component",
         exported: false,
       },
       {
         componentId: "App.tsx:Pure",
-        kind: "component",
         exported: true,
       },
       {
         componentId: "App.tsx:NotObjectProps",
-        kind: "component",
         exported: true,
       },
       {
         componentId: "App.tsx:MissingType",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -176,12 +167,10 @@ const ConstantFunction = () => <div>Hello, World!</div>;
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:DeclaredFunction",
-        kind: "component",
         exported: false,
       },
       {
         componentId: "App.tsx:ConstantFunction",
-        kind: "component",
         exported: false,
       },
     ]);
@@ -201,7 +190,6 @@ export default A;
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:A",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -219,7 +207,6 @@ export default () => {
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:default",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -237,7 +224,6 @@ export default function test(){
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:test",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -255,7 +241,6 @@ export default function(){
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:default",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -293,7 +278,6 @@ export const NotStory = (props) => <Button {...props} />;
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Primary",
-        kind: "story",
         args: null,
         associatedComponent: {
           componentId: "App.tsx:default",
@@ -301,15 +285,18 @@ export const NotStory = (props) => <Button {...props} />;
       },
       {
         componentId: "App.stories.tsx:NotStory",
-        kind: "component",
         exported: true,
       },
     ]);
-    const storyInfo = extractedStories[0];
-    if (storyInfo?.kind !== "story" || !storyInfo.associatedComponent) {
+    const story = extractedStories[0];
+    if (
+      !story ||
+      !("associatedComponent" in story) ||
+      !story.associatedComponent
+    ) {
       throw new Error();
     }
-    expect(await storyInfo.associatedComponent.extractProps()).toEqual({
+    expect(await story.associatedComponent.extractProps()).toEqual({
       props: objectType({
         label: STRING_TYPE,
       }),
@@ -337,13 +324,11 @@ export const NotStory = (props) => <Button {...props} />;
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Primary",
-        kind: "story",
         args: null,
         associatedComponent: null,
       },
       {
         componentId: "App.stories.tsx:NotStory",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -373,12 +358,10 @@ Primary.args = {
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Template",
-        kind: "component",
         exported: false,
       },
       {
         componentId: "App.stories.tsx:Primary",
-        kind: "story",
         args: {
           value: object([
             {
@@ -398,11 +381,15 @@ Primary.args = {
         },
       },
     ]);
-    const storyInfo = extractedStories[1];
-    if (storyInfo?.kind !== "story" || !storyInfo.associatedComponent) {
+    const story = extractedStories[1];
+    if (
+      !story ||
+      !("associatedComponent" in story) ||
+      !story.associatedComponent
+    ) {
       throw new Error();
     }
-    expect(await storyInfo.associatedComponent.extractProps()).toEqual({
+    expect(await story.associatedComponent.extractProps()).toEqual({
       props: objectType({
         label: STRING_TYPE,
       }),
@@ -434,12 +421,10 @@ Primary.args = {
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Template",
-        kind: "component",
         exported: false,
       },
       {
         componentId: "App.stories.tsx:Primary",
-        kind: "story",
         args: {
           value: object([
             {
@@ -485,7 +470,6 @@ export function NotStory() {}
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Example",
-        kind: "story",
         args: {
           value: object([
             {
@@ -501,18 +485,21 @@ export function NotStory() {}
       },
       {
         componentId: "App.stories.tsx:NoArgs",
-        kind: "story",
         args: null,
         associatedComponent: {
           componentId: "App.tsx:default",
         },
       },
     ]);
-    const storyInfo = extractedStories[0];
-    if (storyInfo?.kind !== "story" || !storyInfo.associatedComponent) {
+    const story = extractedStories[0];
+    if (
+      !story ||
+      !("associatedComponent" in story) ||
+      !story.associatedComponent
+    ) {
       throw new Error();
     }
-    expect(await storyInfo.associatedComponent.extractProps()).toEqual({
+    expect(await story.associatedComponent.extractProps()).toEqual({
       props: objectType({
         label: STRING_TYPE,
       }),
@@ -546,7 +533,6 @@ export function NotStory() {}
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Example",
-        kind: "story",
         args: {
           value: object([
             {
@@ -560,7 +546,6 @@ export function NotStory() {}
       },
       {
         componentId: "App.stories.tsx:NoArgs",
-        kind: "story",
         args: null,
         associatedComponent: null,
       },

--- a/component-analyzer/react/src/extract-component.ts
+++ b/component-analyzer/react/src/extract-component.ts
@@ -97,7 +97,6 @@ export async function extractReactComponents(
       );
       return {
         ...baseComponent,
-        kind: "story",
         args: storyArgs
           ? {
               start: storyArgs.getStart(),
@@ -111,7 +110,6 @@ export async function extractReactComponents(
     if (signature) {
       return {
         ...baseComponent,
-        kind: "component",
         exported: isExported,
         extractProps: async () =>
           analyzeReactComponent(
@@ -159,7 +157,7 @@ export async function extractReactComponents(
             path.join(rootDir, filePath)
           )
         ).find((c) => c.componentId === componentId);
-        if (component?.kind !== "component") {
+        if (!component || !("extractProps" in component)) {
           return {
             props: UNKNOWN_TYPE,
             types: {},

--- a/component-analyzer/react/src/index.ts
+++ b/component-analyzer/react/src/index.ts
@@ -51,7 +51,7 @@ export const createComponentAnalyzer = factoryWithDefaultOptions(
             rootDir,
             absoluteFilePath
           )) {
-            if (componentOrStory.kind === "component") {
+            if ("extractProps" in componentOrStory) {
               components.push(componentOrStory);
             } else {
               stories.push(componentOrStory);

--- a/core/src/detect-components.ts
+++ b/core/src/detect-components.ts
@@ -164,7 +164,6 @@ async function detectComponentsCore(
       componentId: component.componentId,
       start,
       end,
-      kind: "component",
       exported: component.exported,
     });
   }
@@ -174,7 +173,6 @@ async function detectComponentsCore(
       componentId: story.componentId,
       start,
       end,
-      kind: "story",
       args: story.args,
       associatedComponentId: story.associatedComponent?.componentId || null,
     });

--- a/core/src/find-files.spec.ts
+++ b/core/src/find-files.spec.ts
@@ -25,9 +25,9 @@ describe("find files", () => {
     await fs.writeFile(path.join(dirPath, "b a r", "foo"), "", "utf8");
     await fs.writeFile(path.join(dirPath, "b a r", "qux", "foo"), "", "utf8");
     expect(await findFiles(dirPath, "**/*")).toEqual([
-      path.join(path.join(dirPath, "foo")),
       path.join(path.join(dirPath, "b a r", "foo")),
       path.join(path.join(dirPath, "bar", "foo")),
+      path.join(path.join(dirPath, "foo")),
     ]);
     expect(await findFiles(path.join(dirPath, "bar"), "**/*")).toEqual([
       path.join(path.join(dirPath, "bar", "foo")),

--- a/core/src/find-files.ts
+++ b/core/src/find-files.ts
@@ -29,7 +29,7 @@ export async function findFiles(
   if (!normalizedRootDirPath.endsWith("/")) {
     normalizedRootDirPath += "/";
   }
-  return files.filter((f) => f.startsWith(normalizedRootDirPath));
+  return files.filter((f) => f.startsWith(normalizedRootDirPath)).sort();
 }
 
 async function findGitRoot(

--- a/framework-plugins/preact/src/extract-component.spec.ts
+++ b/framework-plugins/preact/src/extract-component.spec.ts
@@ -104,12 +104,10 @@ export const AlsoNotAStory = {
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:DeclaredFunction",
-        kind: "component",
         exported: false,
       },
       {
         componentId: "App.tsx:ConstantFunction",
-        kind: "component",
         exported: false,
       },
       // Note: this isn't detected as of October 2021.
@@ -120,22 +118,18 @@ export const AlsoNotAStory = {
       // },
       {
         componentId: "App.tsx:ClassComponent1",
-        kind: "component",
         exported: false,
       },
       {
         componentId: "App.tsx:ForwardRef",
-        kind: "component",
         exported: false,
       },
       {
         componentId: "App.tsx:NotObjectProps",
-        kind: "component",
         exported: true,
       },
       {
         componentId: "App.tsx:MissingType",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -155,12 +149,10 @@ const ConstantFunction = () => <div>Hello, World!</div>;
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:DeclaredFunction",
-        kind: "component",
         exported: false,
       },
       {
         componentId: "App.tsx:ConstantFunction",
-        kind: "component",
         exported: false,
       },
     ]);
@@ -180,7 +172,6 @@ export default A;
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:A",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -198,7 +189,6 @@ export default () => {
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:default",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -216,7 +206,6 @@ export default function test(){
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:test",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -234,7 +223,6 @@ export default function(){
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:default",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -272,7 +260,6 @@ export const NotStory = (props) => <Button {...props} />;
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Primary",
-        kind: "story",
         args: null,
         associatedComponent: {
           componentId: "App.tsx:default",
@@ -280,15 +267,18 @@ export const NotStory = (props) => <Button {...props} />;
       },
       {
         componentId: "App.stories.tsx:NotStory",
-        kind: "component",
         exported: true,
       },
     ]);
-    const storyInfo = extractedStories[0];
-    if (storyInfo?.kind !== "story" || !storyInfo.associatedComponent) {
+    const story = extractedStories[0];
+    if (
+      !story ||
+      !("associatedComponent" in story) ||
+      !story.associatedComponent
+    ) {
       throw new Error();
     }
-    expect(await storyInfo.associatedComponent.extractProps()).toEqual({
+    expect(await story.associatedComponent.extractProps()).toEqual({
       props: objectType({
         label: STRING_TYPE,
       }),
@@ -316,13 +306,11 @@ export const NotStory = (props) => <Button {...props} />;
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Primary",
-        kind: "story",
         args: null,
         associatedComponent: null,
       },
       {
         componentId: "App.stories.tsx:NotStory",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -352,12 +340,10 @@ Primary.args = {
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Template",
-        kind: "component",
         exported: false,
       },
       {
         componentId: "App.stories.tsx:Primary",
-        kind: "story",
         args: {
           value: object([
             {
@@ -403,7 +389,6 @@ export function NotStory() {}
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Example",
-        kind: "story",
         args: {
           value: object([
             {
@@ -419,18 +404,21 @@ export function NotStory() {}
       },
       {
         componentId: "App.stories.tsx:NoArgs",
-        kind: "story",
         args: null,
         associatedComponent: {
           componentId: "App.tsx:default",
         },
       },
     ]);
-    const storyInfo = extractedStories[0];
-    if (storyInfo?.kind !== "story" || !storyInfo.associatedComponent) {
+    const story = extractedStories[0];
+    if (
+      !story ||
+      !("associatedComponent" in story) ||
+      !story.associatedComponent
+    ) {
       throw new Error();
     }
-    expect(await storyInfo.associatedComponent.extractProps()).toEqual({
+    expect(await story.associatedComponent.extractProps()).toEqual({
       props: objectType({
         label: STRING_TYPE,
       }),
@@ -464,7 +452,6 @@ export function NotStory() {}
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Example",
-        kind: "story",
         args: {
           value: object([
             {
@@ -478,7 +465,6 @@ export function NotStory() {}
       },
       {
         componentId: "App.stories.tsx:NoArgs",
-        kind: "story",
         args: null,
         associatedComponent: null,
       },

--- a/framework-plugins/preact/src/extract-component.ts
+++ b/framework-plugins/preact/src/extract-component.ts
@@ -98,7 +98,6 @@ export async function extractPreactComponents(
       );
       return {
         ...baseComponent,
-        kind: "story",
         args: storyArgs
           ? {
               start: storyArgs.getStart(),
@@ -112,7 +111,6 @@ export async function extractPreactComponents(
     if (signature) {
       return {
         ...baseComponent,
-        kind: "component",
         exported: isExported,
         extractProps: async () =>
           analyzePreactComponent(logger, resolver, signature),
@@ -154,7 +152,7 @@ export async function extractPreactComponents(
             path.join(rootDir, filePath)
           )
         ).find((c) => c.componentId === componentId);
-        if (component?.kind !== "component") {
+        if (!component || !("extractProps" in component)) {
           return {
             props: UNKNOWN_TYPE,
             types: {},

--- a/framework-plugins/preact/src/index.ts
+++ b/framework-plugins/preact/src/index.ts
@@ -46,7 +46,7 @@ const preactFrameworkPlugin: FrameworkPluginFactory = {
             rootDir,
             absoluteFilePath
           )) {
-            if (componentOrStory.kind === "component") {
+            if ('extractProps' in componentOrStory) {
               components.push(componentOrStory);
             } else {
               stories.push(componentOrStory);

--- a/framework-plugins/solid/src/extract-component.spec.ts
+++ b/framework-plugins/solid/src/extract-component.spec.ts
@@ -79,17 +79,14 @@ export default Component1;
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:Component1",
-        kind: "component",
         exported: true,
       },
       {
         componentId: "App.tsx:Component2",
-        kind: "component",
         exported: false,
       },
       {
         componentId: "App.tsx:Component3",
-        kind: "component",
         exported: false,
       },
     ]);
@@ -109,12 +106,10 @@ const ConstantFunction = () => <div>Hello, World!</div>;
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:DeclaredFunction",
-        kind: "component",
         exported: true,
       },
       {
         componentId: "App.tsx:ConstantFunction",
-        kind: "component",
         exported: false,
       },
     ]);
@@ -147,15 +142,18 @@ export const NotStory = (props) => <Button {...props} />;
       },
       {
         componentId: "App.stories.tsx:NotStory",
-        kind: "component",
         exported: true,
       },
     ]);
-    const storyInfo = extractedStories[0];
-    if (storyInfo?.kind !== "story" || !storyInfo.associatedComponent) {
+    const story = extractedStories[0];
+    if (
+      !story ||
+      !("associatedComponent" in story) ||
+      !story.associatedComponent
+    ) {
       throw new Error();
     }
-    expect(await storyInfo.associatedComponent.extractProps()).toEqual({
+    expect(await story.associatedComponent.extractProps()).toEqual({
       props: objectType({
         label: STRING_TYPE,
       }),
@@ -188,7 +186,6 @@ export const NotStory = (props) => <Button {...props} />;
       },
       {
         componentId: "App.stories.tsx:NotStory",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -218,7 +215,6 @@ Primary.args = {
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Template",
-        kind: "component",
         exported: false,
       },
       {
@@ -242,11 +238,15 @@ Primary.args = {
         },
       },
     ]);
-    const storyInfo = extractedStories[1];
-    if (storyInfo?.kind !== "story" || !storyInfo.associatedComponent) {
+    const story = extractedStories[1];
+    if (
+      !story ||
+      !("associatedComponent" in story) ||
+      !story.associatedComponent
+    ) {
       throw new Error();
     }
-    expect(await storyInfo.associatedComponent.extractProps()).toEqual({
+    expect(await story.associatedComponent.extractProps()).toEqual({
       props: objectType({
         label: STRING_TYPE,
       }),
@@ -278,7 +278,6 @@ Primary.args = {
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Template",
-        kind: "component",
         exported: false,
       },
       {
@@ -346,11 +345,15 @@ export function NotStory() {}
         },
       },
     ]);
-    const storyInfo = extractedStories[0];
-    if (storyInfo?.kind !== "story" || !storyInfo.associatedComponent) {
+    const story = extractedStories[0];
+    if (
+      !story ||
+      !("associatedComponent" in story) ||
+      !story.associatedComponent
+    ) {
       throw new Error();
     }
-    expect(await storyInfo.associatedComponent.extractProps()).toEqual({
+    expect(await story.associatedComponent.extractProps()).toEqual({
       props: objectType({
         label: STRING_TYPE,
       }),

--- a/framework-plugins/solid/src/extract-component.ts
+++ b/framework-plugins/solid/src/extract-component.ts
@@ -100,7 +100,6 @@ export async function extractSolidComponents(
       );
       return {
         ...baseComponent,
-        kind: "story",
         args: storyArgs
           ? {
               start: storyArgs.getStart(),
@@ -114,7 +113,6 @@ export async function extractSolidComponents(
     if (signature) {
       return {
         ...baseComponent,
-        kind: "component",
         exported: isExported,
         extractProps: async () =>
           analyzeSolidComponent(logger, resolver, signature),
@@ -156,7 +154,7 @@ export async function extractSolidComponents(
             path.join(rootDir, filePath)
           )
         ).find((c) => c.componentId === componentId);
-        if (component?.kind !== "component") {
+        if (!component || !("extractProps" in component)) {
           return {
             props: UNKNOWN_TYPE,
             types: {},

--- a/framework-plugins/solid/src/index.ts
+++ b/framework-plugins/solid/src/index.ts
@@ -46,7 +46,7 @@ const solidFrameworkPlugin: FrameworkPluginFactory = {
             rootDir,
             absoluteFilePath
           )) {
-            if (componentOrStory.kind === "component") {
+            if ("extractProps" in componentOrStory) {
               components.push(componentOrStory);
             } else {
               stories.push(componentOrStory);

--- a/framework-plugins/svelte/src/extract-component.ts
+++ b/framework-plugins/svelte/src/extract-component.ts
@@ -29,7 +29,6 @@ export async function extractSvelteComponents(
           name: inferComponentNameFromSveltePath(absoluteFilePath),
         }),
         offsets: [0, (await entry.read()).length],
-        kind: "component",
         exported: true,
         extractProps: async () =>
           analyzeSvelteComponentFromSFC(resolver, absoluteFilePath + ".ts"),
@@ -55,7 +54,7 @@ export async function extractSvelteComponents(
               path.join(rootDir, filePath)
             )
           ).find((c) => c.componentId === componentId);
-          if (component?.kind !== "component") {
+          if (!component || !("extractProps" in component)) {
             return {
               props: UNKNOWN_TYPE,
               types: {},
@@ -66,7 +65,7 @@ export async function extractSvelteComponents(
       )
     ).map((c) => {
       if (
-        c.kind !== "story" ||
+        !("associatedComponent" in c) ||
         !c.associatedComponent?.componentId.includes(".svelte.ts:")
       ) {
         return c;

--- a/framework-plugins/svelte/src/index.ts
+++ b/framework-plugins/svelte/src/index.ts
@@ -56,7 +56,7 @@ const svelteFrameworkPlugin: FrameworkPluginFactory = {
             rootDir,
             absoluteFilePath
           )) {
-            if (componentOrStory.kind === "component") {
+            if ("extractProps" in componentOrStory) {
               components.push(componentOrStory);
             } else {
               stories.push(componentOrStory);

--- a/framework-plugins/vue2/src/extract-component.spec.ts
+++ b/framework-plugins/vue2/src/extract-component.spec.ts
@@ -102,12 +102,10 @@ export default Component1;
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:Component1",
-        kind: "component",
         exported: true,
       },
       {
         componentId: "App.tsx:Component2",
-        kind: "component",
         exported: false,
       },
     ]);
@@ -127,12 +125,10 @@ const ConstantFunction = () => <div>Hello, World!</div>;
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:DeclaredFunction",
-        kind: "component",
         exported: true,
       },
       {
         componentId: "App.tsx:ConstantFunction",
-        kind: "component",
         exported: false,
       },
     ]);
@@ -150,7 +146,6 @@ export default () => {
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:default",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -168,7 +163,6 @@ export default function test(){
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:test",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -186,7 +180,6 @@ export default function(){
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:default",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -213,18 +206,21 @@ export const Primary = () => ({
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Primary",
-        kind: "story",
         args: null,
         associatedComponent: {
           componentId: "MyComponent.vue:MyComponent",
         },
       },
     ]);
-    const storyInfo = await extractedStories[0];
-    if (storyInfo?.kind !== "story" || !storyInfo.associatedComponent) {
+    const story = await extractedStories[0];
+    if (
+      !story ||
+      !("associatedComponent" in story) ||
+      !story.associatedComponent
+    ) {
       throw new Error();
     }
-    expect(await storyInfo.associatedComponent.extractProps()).toEqual({
+    expect(await story.associatedComponent.extractProps()).toEqual({
       props: objectType({
         label: STRING_TYPE,
       }),
@@ -253,7 +249,6 @@ export const Primary = () => ({
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Primary",
-        kind: "story",
         args: null,
         associatedComponent: null,
       },
@@ -288,7 +283,6 @@ Primary.args = {
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Primary",
-        kind: "story",
         args: {
           value: object([
             {
@@ -308,11 +302,15 @@ Primary.args = {
         },
       },
     ]);
-    const storyInfo = await extractedStories[0];
-    if (storyInfo?.kind !== "story" || !storyInfo.associatedComponent) {
+    const story = await extractedStories[0];
+    if (
+      !story ||
+      !("associatedComponent" in story) ||
+      !story.associatedComponent
+    ) {
       throw new Error();
     }
-    expect(await storyInfo.associatedComponent.extractProps()).toEqual({
+    expect(await story.associatedComponent.extractProps()).toEqual({
       props: objectType({
         label: STRING_TYPE,
       }),
@@ -348,7 +346,6 @@ Primary.args = {
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Primary",
-        kind: "story",
         args: {
           value: object([
             {
@@ -392,7 +389,6 @@ export function NotStory() {}
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Example",
-        kind: "story",
         args: {
           value: object([
             {
@@ -408,18 +404,21 @@ export function NotStory() {}
       },
       {
         componentId: "App.stories.tsx:NoArgs",
-        kind: "story",
         args: null,
         associatedComponent: {
           componentId: "MyComponent.vue:MyComponent",
         },
       },
     ]);
-    const storyInfo = await extractedStories[0];
-    if (storyInfo?.kind !== "story" || !storyInfo.associatedComponent) {
+    const story = await extractedStories[0];
+    if (
+      !story ||
+      !("associatedComponent" in story) ||
+      !story.associatedComponent
+    ) {
       throw new Error();
     }
-    expect(await storyInfo.associatedComponent.extractProps()).toEqual({
+    expect(await story.associatedComponent.extractProps()).toEqual({
       props: objectType({
         label: STRING_TYPE,
       }),
@@ -451,7 +450,6 @@ export function NotStory() {}
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Example",
-        kind: "story",
         args: {
           value: object([
             {
@@ -465,7 +463,6 @@ export function NotStory() {}
       },
       {
         componentId: "App.stories.tsx:NoArgs",
-        kind: "story",
         args: null,
         associatedComponent: null,
       },

--- a/framework-plugins/vue2/src/extract-component.ts
+++ b/framework-plugins/vue2/src/extract-component.ts
@@ -43,7 +43,6 @@ export async function extractVueComponents(
           name: inferComponentNameFromVuePath(vueAbsoluteFilePath),
         }),
         offsets: [0, fileEntry.size()],
-        kind: "component",
         exported: true,
         extractProps: async () =>
           analyzeVueComponentFromTemplate(
@@ -113,7 +112,6 @@ export async function extractVueComponents(
       );
       return {
         ...baseComponent,
-        kind: "story",
         args: {
           start: storyArgs.getStart(),
           end: storyArgs.getEnd(),
@@ -128,7 +126,6 @@ export async function extractVueComponents(
       if (isJsxElement(returnType)) {
         return {
           ...baseComponent,
-          kind: "component",
           exported: isExported,
           extractProps: async () => ({
             // TODO: Handle JSX properties.
@@ -146,7 +143,6 @@ export async function extractVueComponents(
         );
         return {
           ...baseComponent,
-          kind: "story",
           args: null,
           associatedComponent,
         };
@@ -191,7 +187,7 @@ export async function extractVueComponents(
           const component = absoluteFilePath.endsWith(".vue.ts")
             ? vueComponents[0]
             : vueComponents.find((c) => c.componentId === componentId);
-          if (component?.kind !== "component") {
+          if (!component || !("extractProps" in component)) {
             return {
               props: UNKNOWN_TYPE,
               types: {},
@@ -202,7 +198,7 @@ export async function extractVueComponents(
       )
     ).map((c) => {
       if (
-        c.kind !== "story" ||
+        !("associatedComponent" in c) ||
         !c.associatedComponent?.componentId.includes(".vue.ts:")
       ) {
         return c;

--- a/framework-plugins/vue2/src/index.ts
+++ b/framework-plugins/vue2/src/index.ts
@@ -56,7 +56,7 @@ const vue2FrameworkPlugin: FrameworkPluginFactory = {
             rootDir,
             absoluteFilePath
           )) {
-            if (componentOrStory.kind === "component") {
+            if ("extractProps" in componentOrStory) {
               components.push(componentOrStory);
             } else {
               stories.push(componentOrStory);

--- a/framework-plugins/vue3/src/extract-component.spec.ts
+++ b/framework-plugins/vue3/src/extract-component.spec.ts
@@ -96,12 +96,10 @@ export default Component1;
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:Component1",
-        kind: "component",
         exported: true,
       },
       {
         componentId: "App.tsx:Component2",
-        kind: "component",
         exported: false,
       },
     ]);
@@ -121,12 +119,10 @@ const ConstantFunction = () => <div>Hello, World!</div>;
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:DeclaredFunction",
-        kind: "component",
         exported: true,
       },
       {
         componentId: "App.tsx:ConstantFunction",
-        kind: "component",
         exported: false,
       },
     ]);
@@ -144,7 +140,6 @@ export default () => {
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:default",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -162,7 +157,6 @@ export default function test(){
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:test",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -180,7 +174,6 @@ export default function(){
     expect(await extract(APP_TSX)).toMatchObject([
       {
         componentId: "App.tsx:default",
-        kind: "component",
         exported: true,
       },
     ]);
@@ -207,18 +200,21 @@ export const Primary = () => ({
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Primary",
-        kind: "story",
         args: null,
         associatedComponent: {
           componentId: "MyComponent.vue:MyComponent",
         },
       },
     ]);
-    const storyInfo = extractedStories[0];
-    if (storyInfo?.kind !== "story" || !storyInfo.associatedComponent) {
+    const story = extractedStories[0];
+    if (
+      !story ||
+      !("associatedComponent" in story) ||
+      !story.associatedComponent
+    ) {
       throw new Error();
     }
-    expect(await storyInfo.associatedComponent.extractProps()).toEqual({
+    expect(await story.associatedComponent.extractProps()).toEqual({
       props: objectType({
         label: STRING_TYPE,
       }),
@@ -247,7 +243,6 @@ export const Primary = () => ({
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Primary",
-        kind: "story",
         args: null,
         associatedComponent: null,
       },
@@ -285,7 +280,6 @@ Primary.args = {
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Primary",
-        kind: "story",
         args: {
           value: object([
             {
@@ -305,11 +299,15 @@ Primary.args = {
         },
       },
     ]);
-    const storyInfo = extractedStories[0];
-    if (storyInfo?.kind !== "story" || !storyInfo.associatedComponent) {
+    const story = extractedStories[0];
+    if (
+      !story ||
+      !("associatedComponent" in story) ||
+      !story.associatedComponent
+    ) {
       throw new Error();
     }
-    expect(await storyInfo.associatedComponent.extractProps()).toEqual({
+    expect(await story.associatedComponent.extractProps()).toEqual({
       props: objectType({
         label: STRING_TYPE,
       }),
@@ -348,7 +346,6 @@ Primary.args = {
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Primary",
-        kind: "story",
         args: {
           value: object([
             {
@@ -392,7 +389,6 @@ export function NotStory() {}
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Example",
-        kind: "story",
         args: {
           value: object([
             {
@@ -408,18 +404,21 @@ export function NotStory() {}
       },
       {
         componentId: "App.stories.tsx:NoArgs",
-        kind: "story",
         args: null,
         associatedComponent: {
           componentId: "MyComponent.vue:MyComponent",
         },
       },
     ]);
-    const storyInfo = extractedStories[0];
-    if (storyInfo?.kind !== "story" || !storyInfo.associatedComponent) {
+    const story = extractedStories[0];
+    if (
+      !story ||
+      !("associatedComponent" in story) ||
+      !story.associatedComponent
+    ) {
       throw new Error();
     }
-    expect(await storyInfo.associatedComponent.extractProps()).toEqual({
+    expect(await story.associatedComponent.extractProps()).toEqual({
       props: objectType({
         label: STRING_TYPE,
       }),
@@ -451,7 +450,6 @@ export function NotStory() {}
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.tsx:Example",
-        kind: "story",
         args: {
           value: object([
             {
@@ -465,7 +463,6 @@ export function NotStory() {}
       },
       {
         componentId: "App.stories.tsx:NoArgs",
-        kind: "story",
         args: null,
         associatedComponent: null,
       },

--- a/framework-plugins/vue3/src/extract-component.ts
+++ b/framework-plugins/vue3/src/extract-component.ts
@@ -43,7 +43,6 @@ export async function extractVueComponents(
           name: inferComponentNameFromVuePath(vueAbsoluteFilePath),
         }),
         offsets: [0, fileEntry.size()],
-        kind: "component",
         exported: true,
         extractProps: async () =>
           analyzeVueComponentFromTemplate(
@@ -113,7 +112,6 @@ export async function extractVueComponents(
       );
       return {
         ...baseComponent,
-        kind: "story",
         args: {
           start: storyArgs.getStart(),
           end: storyArgs.getEnd(),
@@ -128,7 +126,6 @@ export async function extractVueComponents(
       if (isJsxElement(returnType)) {
         return {
           ...baseComponent,
-          kind: "component",
           exported: isExported,
           extractProps: async () => ({
             // TODO: Handle JSX properties.
@@ -146,7 +143,6 @@ export async function extractVueComponents(
         );
         return {
           ...baseComponent,
-          kind: "story",
           args: null,
           associatedComponent,
         };
@@ -191,7 +187,7 @@ export async function extractVueComponents(
           const component = absoluteFilePath.endsWith(".vue.ts")
             ? vueComponents[0]
             : vueComponents.find((c) => c.componentId === componentId);
-          if (component?.kind !== "component") {
+          if (!component || !("extractProps" in component)) {
             return {
               props: UNKNOWN_TYPE,
               types: {},
@@ -202,7 +198,7 @@ export async function extractVueComponents(
       )
     ).map((c) => {
       if (
-        c.kind !== "story" ||
+        !("associatedComponent" in c) ||
         !c.associatedComponent?.componentId.includes(".vue.ts:")
       ) {
         return c;

--- a/framework-plugins/vue3/src/index.ts
+++ b/framework-plugins/vue3/src/index.ts
@@ -59,7 +59,7 @@ const vue3FrameworkPlugin: FrameworkPluginFactory = {
             rootDir,
             absoluteFilePath
           )) {
-            if (componentOrStory.kind === "component") {
+            if ("extractProps" in componentOrStory) {
               components.push(componentOrStory);
             } else {
               stories.push(componentOrStory);

--- a/storybook-helpers/src/extract-csf3-stories.spec.ts
+++ b/storybook-helpers/src/extract-csf3-stories.spec.ts
@@ -63,7 +63,6 @@ export function NotStory() {}
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.jsx:Example",
-        kind: "story",
         args: {
           value: object([
             {
@@ -79,7 +78,6 @@ export function NotStory() {}
       },
       {
         componentId: "App.stories.jsx:NoArgs",
-        kind: "story",
         args: null,
         associatedComponent: {
           componentId: "App.tsx:Button",
@@ -112,7 +110,6 @@ export const Example = {
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.jsx:Example",
-        kind: "story",
         args: {
           value: object([
             {
@@ -155,7 +152,6 @@ export function NotStory() {}
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.jsx:Example",
-        kind: "story",
         args: {
           value: object([
             {
@@ -171,7 +167,6 @@ export function NotStory() {}
       },
       {
         componentId: "App.stories.jsx:NoArgs",
-        kind: "story",
         args: null,
         associatedComponent: {
           componentId: "App.tsx:Button",
@@ -207,7 +202,6 @@ export function NotStory() {}
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.jsx:Example",
-        kind: "story",
         args: {
           value: object([
             {
@@ -223,7 +217,6 @@ export function NotStory() {}
       },
       {
         componentId: "App.stories.jsx:NoArgs",
-        kind: "story",
         args: null,
         associatedComponent: {
           componentId: "App.tsx:default",
@@ -263,7 +256,6 @@ export function NotStory() {}
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.jsx:Example",
-        kind: "story",
         args: {
           value: object([
             {
@@ -279,7 +271,6 @@ export function NotStory() {}
       },
       {
         componentId: "App.stories.jsx:NoArgs",
-        kind: "story",
         args: null,
         associatedComponent: {
           componentId: "App.tsx:Button",
@@ -319,7 +310,6 @@ export function NotStory() {}
     expect(extractedStories).toMatchObject([
       {
         componentId: "App.stories.jsx:Example",
-        kind: "story",
         args: {
           value: object([
             {
@@ -335,7 +325,6 @@ export function NotStory() {}
       },
       {
         componentId: "App.stories.jsx:NoArgs",
-        kind: "story",
         args: null,
         associatedComponent: {
           componentId: "App.tsx:Button",

--- a/storybook-helpers/src/extract-csf3-stories.ts
+++ b/storybook-helpers/src/extract-csf3-stories.ts
@@ -66,7 +66,6 @@ export async function extractCsf3Stories(
         storyComponent || storiesInfo.component || null
       );
       stories.push({
-        kind: "story",
         componentId: generateComponentId({
           filePath: path.relative(rootDir, sourceFile.fileName),
           name,


### PR DESCRIPTION
This is no longer useful in public APIs since we no longer mix them up in the same list.