### PR TITLE
fix: remove Node polyfill by default

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -32,7 +32,6 @@
     "@previewjs/vfs": "^2.1.2",
     "assert-never": "^1.2.1",
     "axios": "^1.6.8",
-    "esbuild-plugin-polyfill-node": "^0.3.0",
     "exclusive-promises": "^1.0.3",
     "express": "^4.19.2",
     "fs-extra": "^11.2.0",

--- a/core/src/vite/vite-manager.ts
+++ b/core/src/vite/vite-manager.ts
@@ -11,7 +11,6 @@ import type {
   ReaderListenerInfo,
 } from "@previewjs/vfs";
 import type { Alias } from "@rollup/plugin-alias";
-import { polyfillNode } from "esbuild-plugin-polyfill-node";
 import { exclusivePromiseRunner } from "exclusive-promises";
 import express from "express";
 import fs from "fs-extra";
@@ -369,14 +368,6 @@ export class ViteManager {
         ...config.vite,
         configFile: false,
         root: this.options.rootDir,
-        optimizeDeps: {
-          entries: [],
-          esbuildOptions: {
-            // TODO: Remove this annotation once upgraded to Vite 5.
-            // @ts-ignore incompatible esbuild versions with Vite 4
-            plugins: [polyfillNode()],
-          },
-        },
         server: {
           middlewareMode: true,
           hmr: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,9 +331,6 @@ importers:
       axios:
         specifier: ^1.6.8
         version: 1.6.8
-      esbuild-plugin-polyfill-node:
-        specifier: ^0.3.0
-        version: 0.3.0(esbuild@0.20.2)
       exclusive-promises:
         specifier: ^1.0.3
         version: 1.0.3


### PR DESCRIPTION
This can be added back with a simple Vite config such as:

```
import { polyfillNode } from "esbuild-plugin-polyfill-node";

export default {
  optimizeDeps: {
    plugins: [polyfillNode()],
  }
}
```