### PR TITLE
fix: patch `handleHotUpdate` properly

### DIFF
--- a/core/src/vite/vite-manager.ts
+++ b/core/src/vite/vite-manager.ts
@@ -613,8 +613,8 @@ function replaceHandleHotUpdate(reader: Reader, plugins: vite.Plugin[]) {
         : plugin.handleHotUpdate.handler;
     return {
       ...plugin,
-      handleHotUpdate: async (ctx: vite.HmrContext) => {
-        await handleHotUpdate({
+      handleHotUpdate: async function (ctx: vite.HmrContext) {
+        await handleHotUpdate.call(this, {
           ...ctx,
           read: async () => {
             const entry = await reader.read(ctx.file);


### PR DESCRIPTION
While the current patch code works fine as `this` is `undefined` for current Vite, Vite 7+ will pass the context (https://github.com/vitejs/vite/pull/19936) and the current code doesn't work anymore.
This PR changes the code to call the hook function with the original `this`.

This PR should fix the ecosystem-ci failure.
https://github.com/vitejs/vite-ecosystem-ci/actions/runs/15291891294/job/43012757742#step:8:3335
